### PR TITLE
use png for html vignette figures

### DIFF
--- a/vignettes/MCMC-diagnostics.Rmd
+++ b/vignettes/MCMC-diagnostics.Rmd
@@ -18,7 +18,7 @@ library("ggplot2")
 library("gridExtra")
 library("rstan")
 knitr::opts_chunk$set(
-  dev = "pdf",
+  dev = "png",
   fig.align = "center",
   fig.width = 4,
   fig.height = 3,

--- a/vignettes/MCMC.Rmd
+++ b/vignettes/MCMC.Rmd
@@ -14,7 +14,7 @@ vignette: >
 ```{r, settings, include=FALSE}
 library(bayesplot)
 knitr::opts_chunk$set(
-  dev = "pdf",
+  dev = "png",
   fig.align = "center",
   fig.width = 6,
   fig.height = 4,

--- a/vignettes/PPC.Rmd
+++ b/vignettes/PPC.Rmd
@@ -14,7 +14,7 @@ vignette: >
 ```{r, settings, include=FALSE}
 library("bayesplot")
 knitr::opts_chunk$set(
-  dev = "pdf",
+  dev = "png",
   fig.align = "center",
   fig.width = 4,
   fig.height = 4,


### PR DESCRIPTION
The figures are not showing up in the CRAN vignettes. 

If you need both pdf and png output, try using a vector with `c("png", "pdf")` in the `dev` option.