### PR TITLE
Axis title functions without element blank

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bayesplot 1.0.0.9000
 
+* `xaxis_title(FALSE)` and `yaxis_title(FALSE)` now set axis titles to `NULL` rather than changing theme elements to element_blank. This makes it easier to add axis titles to plots that don’t have them by default.
+
 # bayesplot 1.0.0
 
 * Initial CRAN release

--- a/R/bayesplot-helpers.R
+++ b/R/bayesplot-helpers.R
@@ -13,8 +13,8 @@
 #'   For functions ending in \code{_bg}, \code{...} is passed to
 #'   \code{\link[ggplot2]{element_rect}}.
 #'
-#'   For functions ending in \code{_text}, \code{...} is passed to
-#'   \code{\link[ggplot2]{element_text}}.
+#'   For functions ending in \code{_text} or \code{_title}, \code{...} is passed
+#'   to \code{\link[ggplot2]{element_text}}.
 #'
 #'   For \code{xaxis_ticks} and \code{yaxis_ticks}, \code{...} is passed to
 #'   \code{\link[ggplot2]{element_line}}.
@@ -303,10 +303,9 @@ legend_text <- function(...) {
 #' @rdname bayesplot-helpers
 #' @export
 xaxis_title <- function(on = TRUE, ...) {
-  theme(axis.title.x = if (on)
-    element_text(...)
-    else
-      element_blank())
+  if (!on)
+    return(xlab(NULL))
+  theme(axis.title.x = element_text(...))
 }
 #' @rdname bayesplot-helpers
 #' @export
@@ -327,10 +326,9 @@ xaxis_ticks <- function(on = TRUE, ...) {
 #' @rdname bayesplot-helpers
 #' @export
 yaxis_title <- function(on = TRUE, ...) {
-  theme(axis.title.y = if (on)
-    element_text(...)
-    else
-      element_blank())
+  if (!on)
+    return(ylab(NULL))
+  theme(axis.title.y = element_text(...))
 }
 #' @rdname bayesplot-helpers
 #' @export

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -125,14 +125,14 @@ test_that("facet_text returns correct theme object", {
 
 # axis titles -------------------------------------------------------------
 test_that("xaxis_title returns correct theme object", {
-  expect_identical(xaxis_title(FALSE), theme(axis.title.x = element_blank()))
+  expect_identical(xaxis_title(FALSE), xlab(NULL))
   expect_equal(
     xaxis_title(face = "bold", angle = 30),
     theme(axis.title.x = element_text(face = "bold", angle = 30))
   )
 })
 test_that("yaxis_title returns correct theme object", {
-  expect_identical(yaxis_title(FALSE), theme(axis.title.y = element_blank()))
+  expect_identical(yaxis_title(FALSE), ylab(NULL))
   expect_equal(
     yaxis_title(face = "bold", angle = 30),
     theme(axis.title.y = element_text(face = "bold", angle = 30))


### PR DESCRIPTION
`xaxis_title(FALSE)` and `yaxis_title(FALSE)` now set axis titles to `NULL` rather than changing theme elements to `element_blank`. This makes it easier to add axis titles to plots that don’t have them by default.