### PR TITLE
Allow recycling transformations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,8 @@ but there are not actually any divergent transitions.
 
 #### New Features
 * Introduce `ppc_rootogram` for use with models for count data. (#28)
-* Recyle transformations if `transformations` argument is specified as a 
-single function rather than a named list. (#64)
+* For `mcmc_*` functions, recyle transformations if `transformations` argument
+is specified as a single function rather than a named list. (#64)
 
 
 # bayesplot 1.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ but there are not actually any divergent transitions.
 
 #### New Features
 * Introduce `ppc_rootogram` for use with models for count data. (#28)
+* Recyle transformations if `transformations` argument is specified as a 
+single function rather than a named list. (#64)
 
 
 # bayesplot 1.1.0

--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -176,18 +176,18 @@ prepare_mcmc_array <-
     }
     x <- validate_mcmc_x(x)
 
-    parnames <- if (is.matrix(x)) {
-      colnames(x)
-    } else if (is.array(x)) {
-      parameter_names(x)
-    }
-    if (is.null(parnames))
-      stop("No parameter names found.")
-
+    parnames <- parameter_names(x)
     pars <-
       select_parameters(explicit = pars,
                         patterns = regex_pars,
                         complete = parnames)
+
+    # possibly recycle transformations (apply same to all pars)
+    if (is.function(transformations) ||
+        (is.character(transformations) && length(transformations) == 1)) {
+      transformations <- rep(list(transformations), length(pars))
+      transformations <- setNames(transformations, pars)
+    }
 
     if (is.matrix(x)) {
       x <- x[, pars, drop=FALSE]

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -76,6 +76,17 @@
 #' p + legend_move("bottom")
 #' p + legend_move("none") # or p + legend_none()
 #'
+#' \donttest{
+#' # apply transformations
+#' mcmc_intervals(
+#'   x,
+#'   pars = c("beta[2]", "sigma"),
+#'   transformations = list("sigma" = "log", "beta[2]" = function(x) x + 3)
+#' )
+#'
+#' # apply same transformation to all selected parameters
+#' mcmc_intervals(x, regex_pars = "beta", transformations = "exp")
+#' }
 #'
 #' \dontrun{
 #' # example using fitted model from rstanarm package

--- a/man-roxygen/args-transformations.R
+++ b/man-roxygen/args-transformations.R
@@ -1,11 +1,14 @@
-#' @param transformations An optional named list specifying transformations to
-#'   apply to parameters. The name of each list element should be a parameter
-#'   name and the content of each list element should be a function (or any item
-#'   to match as a function via \code{\link{match.fun}}, e.g. a string naming a
-#'   function). If a function in the list of transformations is specified by its
-#'   name as a string (e.g. \code{"log"}), then it can be used to construct a
-#'   new parameter label for the appropriate parameter (e.g.
-#'   \code{"log(sigma)"}). If a function itself is specified (e.g. \code{log} or
-#'   \code{function(x) log(x)}) then \code{"t"} is used in the new parameter
-#'   label to indicate that the parameter is transformed (e.g.
-#'   \code{"t(sigma)"}).
+#' @param transformations Optionally, transformations to apply to parameters
+#'   before plotting. If \code{transformations} is a function or a single string
+#'   naming a function then that function will be used to transform all
+#'   parameters. To apply transformations to particular parameters, the
+#'   \code{transformations} argument can be a named list with length equal to
+#'   the number of parameters to be transfomred. The name of each list element
+#'   should be a parameter name and the content of each list element should be a
+#'   function (or any item to match as a function via \code{\link{match.fun}},
+#'   e.g. a string naming a function). If a function is specified by its name as
+#'   a string (e.g. \code{"log"}), then it can be used to construct a new
+#'   parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+#'   If a function itself is specified (e.g. \code{log} or \code{function(x)
+#'   log(x)}) then \code{"t"} is used in the new parameter label to indicate
+#'   that the parameter is transformed (e.g. \code{"t(sigma)"}).

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -38,17 +38,20 @@ allowed inputs.}
 parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
-\item{transformations}{An optional named list specifying transformations to
-apply to parameters. The name of each list element should be a parameter
-name and the content of each list element should be a function (or any item
-to match as a function via \code{\link{match.fun}}, e.g. a string naming a
-function). If a function in the list of transformations is specified by its
-name as a string (e.g. \code{"log"}), then it can be used to construct a
-new parameter label for the appropriate parameter (e.g.
-\code{"log(sigma)"}). If a function itself is specified (e.g. \code{log} or
-\code{function(x) log(x)}) then \code{"t"} is used in the new parameter
-label to indicate that the parameter is transformed (e.g.
-\code{"t(sigma)"}).}
+\item{transformations}{Optionally, transformations to apply to parameters
+before plotting. If \code{transformations} is a function or a single string
+naming a function then that function will be used to transform all
+parameters. To apply transformations to particular parameters, the
+\code{transformations} argument can be a named list with length equal to
+the number of parameters to be transfomred. The name of each list element
+should be a parameter name and the content of each list element should be a
+function (or any item to match as a function via \code{\link{match.fun}},
+e.g. a string naming a function). If a function is specified by its name as
+a string (e.g. \code{"log"}), then it can be used to construct a new
+parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+If a function itself is specified (e.g. \code{log} or \code{function(x)
+log(x)}) then \code{"t"} is used in the new parameter label to indicate
+that the parameter is transformed (e.g. \code{"t(sigma)"}).}
 
 \item{facet_args}{Arguments (other than \code{facets}) passed to
 \code{\link[ggplot2]{facet_wrap}} (if \code{by_chain} is \code{FALSE}) or

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -28,17 +28,20 @@ allowed inputs.}
 parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
-\item{transformations}{An optional named list specifying transformations to
-apply to parameters. The name of each list element should be a parameter
-name and the content of each list element should be a function (or any item
-to match as a function via \code{\link{match.fun}}, e.g. a string naming a
-function). If a function in the list of transformations is specified by its
-name as a string (e.g. \code{"log"}), then it can be used to construct a
-new parameter label for the appropriate parameter (e.g.
-\code{"log(sigma)"}). If a function itself is specified (e.g. \code{log} or
-\code{function(x) log(x)}) then \code{"t"} is used in the new parameter
-label to indicate that the parameter is transformed (e.g.
-\code{"t(sigma)"}).}
+\item{transformations}{Optionally, transformations to apply to parameters
+before plotting. If \code{transformations} is a function or a single string
+naming a function then that function will be used to transform all
+parameters. To apply transformations to particular parameters, the
+\code{transformations} argument can be a named list with length equal to
+the number of parameters to be transfomred. The name of each list element
+should be a parameter name and the content of each list element should be a
+function (or any item to match as a function via \code{\link{match.fun}},
+e.g. a string naming a function). If a function is specified by its name as
+a string (e.g. \code{"log"}), then it can be used to construct a new
+parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+If a function itself is specified (e.g. \code{log} or \code{function(x)
+log(x)}) then \code{"t"} is used in the new parameter label to indicate
+that the parameter is transformed (e.g. \code{"t(sigma)"}).}
 
 \item{...}{Currently unused.}
 
@@ -118,6 +121,17 @@ p <- mcmc_areas(x, pars = c("alpha", "beta[4]"), rhat = c(1, 1.1))
 p + legend_move("bottom")
 p + legend_move("none") # or p + legend_none()
 
+\donttest{
+# apply transformations
+mcmc_intervals(
+  x,
+  pars = c("beta[2]", "sigma"),
+  transformations = list("sigma" = "log", "beta[2]" = function(x) x + 3)
+)
+
+# apply same transformation to all selected parameters
+mcmc_intervals(x, regex_pars = "beta", transformations = "exp")
+}
 
 \dontrun{
 # example using fitted model from rstanarm package

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -20,17 +20,20 @@ for \code{mcmc_scatter} only two parameters can be selected.)}
 parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
-\item{transformations}{An optional named list specifying transformations to
-apply to parameters. The name of each list element should be a parameter
-name and the content of each list element should be a function (or any item
-to match as a function via \code{\link{match.fun}}, e.g. a string naming a
-function). If a function in the list of transformations is specified by its
-name as a string (e.g. \code{"log"}), then it can be used to construct a
-new parameter label for the appropriate parameter (e.g.
-\code{"log(sigma)"}). If a function itself is specified (e.g. \code{log} or
-\code{function(x) log(x)}) then \code{"t"} is used in the new parameter
-label to indicate that the parameter is transformed (e.g.
-\code{"t(sigma)"}).}
+\item{transformations}{Optionally, transformations to apply to parameters
+before plotting. If \code{transformations} is a function or a single string
+naming a function then that function will be used to transform all
+parameters. To apply transformations to particular parameters, the
+\code{transformations} argument can be a named list with length equal to
+the number of parameters to be transfomred. The name of each list element
+should be a parameter name and the content of each list element should be a
+function (or any item to match as a function via \code{\link{match.fun}},
+e.g. a string naming a function). If a function is specified by its name as
+a string (e.g. \code{"log"}), then it can be used to construct a new
+parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+If a function itself is specified (e.g. \code{log} or \code{function(x)
+log(x)}) then \code{"t"} is used in the new parameter label to indicate
+that the parameter is transformed (e.g. \code{"t(sigma)"}).}
 
 \item{...}{Currently ignored.}
 

--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -27,17 +27,20 @@ allowed inputs.}
 parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
-\item{transformations}{An optional named list specifying transformations to
-apply to parameters. The name of each list element should be a parameter
-name and the content of each list element should be a function (or any item
-to match as a function via \code{\link{match.fun}}, e.g. a string naming a
-function). If a function in the list of transformations is specified by its
-name as a string (e.g. \code{"log"}), then it can be used to construct a
-new parameter label for the appropriate parameter (e.g.
-\code{"log(sigma)"}). If a function itself is specified (e.g. \code{log} or
-\code{function(x) log(x)}) then \code{"t"} is used in the new parameter
-label to indicate that the parameter is transformed (e.g.
-\code{"t(sigma)"}).}
+\item{transformations}{Optionally, transformations to apply to parameters
+before plotting. If \code{transformations} is a function or a single string
+naming a function then that function will be used to transform all
+parameters. To apply transformations to particular parameters, the
+\code{transformations} argument can be a named list with length equal to
+the number of parameters to be transfomred. The name of each list element
+should be a parameter name and the content of each list element should be a
+function (or any item to match as a function via \code{\link{match.fun}},
+e.g. a string naming a function). If a function is specified by its name as
+a string (e.g. \code{"log"}), then it can be used to construct a new
+parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+If a function itself is specified (e.g. \code{log} or \code{function(x)
+log(x)}) then \code{"t"} is used in the new parameter label to indicate
+that the parameter is transformed (e.g. \code{"t(sigma)"}).}
 
 \item{facet_args}{Arguments (other than \code{facets}) passed to
 \code{\link[ggplot2]{facet_wrap}} to control faceting.}

--- a/tests/testthat/test-helpers-mcmc.R
+++ b/tests/testthat/test-helpers-mcmc.R
@@ -196,6 +196,15 @@ test_that("apply_transformations works", {
   expect_equal(mat_trans[, "beta[1]"], exp(mat[, "beta[1]"]))
 })
 
+test_that("transformations recycled properly if not a named list", {
+  # if transformations is a single string naming a function
+  x <- prepare_mcmc_array(arr, regex_pars = "beta", transformations = "exp")
+  expect_identical(parameter_names(x), c("exp(beta[1])", "exp(beta[2])"))
+
+  # if transformations is a single function
+  x <- prepare_mcmc_array(arr, pars = c("beta[1]", "sigma"), transformations = exp)
+  expect_identical(parameter_names(x), c("t(beta[1])", "t(sigma)"))
+})
 
 # rhat and neff helpers ---------------------------------------------------
 test_that("factor_rhat works", {


### PR DESCRIPTION
Resolves #64 

If the `transformations` argument is specified as a single function object or string naming a function then that transformation will be applied to all parameters. If specified as a named list then the behavior is the same as before. 

-----------------

### Example usage 
```r
x <- example_mcmc_draws()
mcmc_intervals(x, regex_pars = "beta", transformations = "exp")
mcmc_intervals(x, regex_pars = "beta", transformations = exp) 
```

