### PR TITLE
add bias plot example to mcmc recover intervals

### DIFF
--- a/R/mcmc-recover.R
+++ b/R/mcmc-recover.R
@@ -69,6 +69,8 @@
 #' mcmc_recover_intervals(draws, true, batch = 1:4)
 #' # same but in a different order
 #' mcmc_recover_intervals(draws, true, batch = c(1, 3, 4, 2))
+#' # present as bias by centering with true values
+#' mcmc_recover_intervals(sweep(draws, 2, true), rep(0, ncol(draws))) + hline_0()
 #' }
 #'
 NULL


### PR DESCRIPTION
As discussed in my original feature request.

This adds a an example to the mcmc recover intervals page which shows how one can quickly get a bias plot which is simply a centering by the true values. I do find this plot much easier to read. However, the bias has to be understood in the context of a prior being present which may be visible or not depending on the amount of data relative to the prior.

