### PR TITLE
ppc_violin_grouped: plot y as violin, too

### DIFF
--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -371,12 +371,10 @@ ppc_violin_grouped <- function(y, yrep, group, ...,
       draw_quantiles = probs,
       alpha = alpha
     ) +
-    geom_point(
+    geom_violin(
       data = plot_data[is_y,, drop = FALSE],
       aes_(fill = "y", color = "y"),
-      shape = 21,
-      alpha = 0.9,
-      size = size
+      alpha = 0.9
     ) +
     scale_fill_ppc_dist(values = c(NA, get_color("l"))) +
     scale_color_ppc_dist() +

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -354,7 +354,7 @@ ppc_ecdf_overlay <- function(y, yrep, ...,
 #'   \code{draw_quantiles} argument to specify at which quantiles to draw
 #'   horizontal lines. Set to \code{NULL} to remove the lines.
 #' @param ydraw a character vector specifying how to draw y. Takes one of the 
-#'   following three options: "violin" (draw y as \code{\link[ggplot]{geom_violin}}, too), 
+#'   following three options: "violin" (draw y as \code{\link[ggplot2]{geom_violin}}, too), 
 #'   "point" (draw y as horizontally jittered points, i.e. as \code{\link[ggplot2]{geom_jitter}}) or 
 #'   "both" (draw y as both \code{\link[ggplot2]{geom_violin}} and \code{\link[ggplot2]{geom_jitter}}).
 #'   Defaults to "violin".

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -72,8 +72,8 @@ pertaining to the corresponding value of \code{y}.}
 \code{draw_quantiles} argument to specify at which quantiles to draw
 horizontal lines. Set to \code{NULL} to remove the lines.}
 
-\item{ydraw}{a character vector to specify how to draw y. Takes one of the 
-following three options: "violin" (draw y as \code{\link[ggplot]{geom_violin}}, too), 
+\item{ydraw}{a character vector specifying how to draw y. Takes one of the 
+following three options: "violin" (draw y as \code{\link[ggplot2]{geom_violin}}, too), 
 "point" (draw y as horizontally jittered points, i.e. as \code{\link[ggplot2]{geom_jitter}}) or 
 "both" (draw y as both \code{\link[ggplot2]{geom_violin}} and \code{\link[ggplot2]{geom_jitter}}).
 Defaults to "violin".}
@@ -81,7 +81,7 @@ Defaults to "violin".}
 \item{jitter}{the amount of horizontal jitter if y is drawn as \code{\link[ggplot2]{geom_jitter}} (i.e., if ydraw is set to "point" or "both").
 Default is NULL, implying \code{\link[ggplot2]{geom_jitter}}'s default.}
 
-\item{yalpha}{the transparency of the jittered y points. Only used if ydraw is set to "point" or "both".}
+\item{yalpha}{the transparency of the jittered y points. Only used if ydraw is set to "point" or "both". Default is 0.1}
 }
 \value{
 A ggplot object that can be further customized using the

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -28,8 +28,8 @@ ppc_dens_overlay(y, yrep, ..., trim = FALSE, size = 0.25, alpha = 0.7)
 
 ppc_ecdf_overlay(y, yrep, ..., pad = TRUE, size = 0.25, alpha = 0.7)
 
-ppc_violin_grouped(y, yrep, group, ..., probs = c(0.1, 0.5, 0.9), size = 1,
-  alpha = 1)
+ppc_violin_grouped(y, yrep, group, ..., probs = c(0.1, 0.5, 0.9),
+  ydraw = "violin", jitter = NULL, yalpha = 0.1, size = 1, alpha = 1)
 }
 \arguments{
 \item{y}{A vector of observations. See \strong{Details}.}
@@ -71,6 +71,17 @@ pertaining to the corresponding value of \code{y}.}
 \item{probs}{A numeric vector passed to \code{\link[ggplot2]{geom_violin}}'s
 \code{draw_quantiles} argument to specify at which quantiles to draw
 horizontal lines. Set to \code{NULL} to remove the lines.}
+
+\item{ydraw}{a character vector to specify how to draw y. Takes one of the 
+following three options: "violin" (draw y as \code{\link[ggplot]{geom_violin}}, too), 
+"point" (draw y as horizontally jittered points, i.e. as \code{\link[ggplot2]{geom_jitter}}) or 
+"both" (draw y as both \code{\link[ggplot2]{geom_violin}} and \code{\link[ggplot2]{geom_jitter}}).
+Defaults to "violin".}
+
+\item{jitter}{the amount of horizontal jitter if y is drawn as \code{\link[ggplot2]{geom_jitter}} (i.e., if ydraw is set to "point" or "both").
+Default is NULL, implying \code{\link[ggplot2]{geom_jitter}}'s default.}
+
+\item{yalpha}{the transparency of the jittered y points. Only used if ydraw is set to "point" or "both".}
 }
 \value{
 A ggplot object that can be further customized using the
@@ -154,6 +165,10 @@ color_scheme_set("gray")
 ppc_violin_grouped(y, yrep, group, size = 1.5)
 \donttest{
 ppc_violin_grouped(y, yrep, group, alpha = 0)
+
+# examples to show non-default options of ppc_violin_grouped() for y-drawing 
+ppc_violin_grouped(y, yrep, group, alpha = 0, ydraw = "point", size = 2, yalpha = 0.5, jitter = 0.2)
+ppc_violin_grouped(y, yrep, group, alpha = 0, ydraw = "both", size = 2, yalpha = 0.5, jitter = 0.2)
 }
 
 }


### PR DESCRIPTION
I plotted a reaction time analysis using ppc_violin_grouped and got this:

![pointdata](https://cloud.githubusercontent.com/assets/4533862/23403818/2ced258c-fdb2-11e6-9258-0dd45b8f6e19.png)

However, I personally find this plot more informative as it shows the density of the empirical data also:

![violindata](https://cloud.githubusercontent.com/assets/4533862/23403821/30e123c8-fdb2-11e6-8ca3-91514f6a132f.png)

I created a pull request to deliver the solution to my problem instead of just opening an issue and `complaining`. Possibly, however, there are reasons out of my knowledge why the data is plotted as `geom_point` and not `geom_violin`. 
I'm also not sure about any possible conventions regarding the plotting style of data. I found the current style easy to see for my example.