### PR TITLE
Convert parameter_names.matrix to parameter_names.default

### DIFF
--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -118,10 +118,9 @@ parameter_names.array <- function(x) {
   stopifnot(is_3d_array(x))
   dimnames(x)[[3]] %||% stop("No parameter names found.")
 }
-parameter_names.matrix <- function(x) {
+parameter_names.default <- function(x) {
   colnames(x) %||% stop("No parameter names found.")
 }
-
 
 # Check if an object is a 3-D array
 is_3d_array <- function(x) {


### PR DESCRIPTION
Small change, previously I was able to use `mcmc` objects from `coda` with `bayesplot`, but due to the change of `parameter_names` into S3 method, this is no longer possible, as there are only methods for objects of class `matrix` and `array`. As `mcmc` object is basically vector or matrix, the matrix method should be applicable to `mcmc` objects as well (in matrix case). And there are perhaps other similar cases. So I changed the `parameter_names.matrix` to default method, which shouldn't break anything but makes the method and an all the function which use it more robust.