### PR TITLE
Optional plot theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
 # bayesplot 1.2.0.9999
 
+* `bayesplot::theme_default` is now set as the default ggplot2 plotting theme
+when **bayesplot** is loaded, which makes changing the default theme using
+`ggplot2::theme_set` possible. Thanks to @gavinsimpson. (#87)
 * `mcmc_hist` and `mcmc_hist_by_chain` now take a `freq` argument that defaults
 to `TRUE` (behavior is like `freq` argument to R's `hist` function).
+* Using a `ts` object for `y` in PPC plots no longer results in an error. Thanks
+to @helske. (#94)
 
 # bayesplot 1.2.0
 

--- a/R/bayesplot-ggplot-themes.R
+++ b/R/bayesplot-ggplot-themes.R
@@ -1,11 +1,10 @@
-#' Default plotting theme
+#' Default bayesplot plotting theme
 #'
 #' The \code{\link{theme_default}} function returns the default ggplot
-#' \link{theme} used by the \pkg{bayesplot} plotting functions. Many of the
-#' individual plotting functions also make small alterations to the default
-#' theme using the convenience functions documented at \link{bayesplot-helpers}.
-#' To use a different theme simply add that theme to the ggplot objects created
-#' by the \pkg{bayesplot} plotting functions (see \strong{Examples}, below).
+#' \link{theme} used by the \pkg{bayesplot} plotting functions.
+#' After loading the \pkg{bayesplot} package, this theme will be the default for
+#' \emph{all} graphs made with \pkg{ggplot2}. See the \strong{Details} section,
+#' below.
 #'
 #' @export
 #' @param base_size,base_family Base font size and family (passed to
@@ -15,6 +14,13 @@
 #'   \code{"serif"}, respectively.
 #'
 #' @return A ggplot \link[ggplot2]{theme} object.
+#'
+#' @details After loading \pkg{bayesplot}, if you subsequently change the
+#' default \pkg{ggplot2} theme (i.e., by calling
+#' \code{\link[ggplot2]{theme_set}} or loading a different package that changes
+#' the theme) then \pkg{bayesplot} will use that theme instead. To change back
+#' to the default \pkg{bayesplot} theme use \code{bayesplot::theme_default()} as
+#' the argument to \code{\link[ggplot2]{theme_set}}.
 #'
 #' @template seealso-helpers
 #' @template seealso-colors
@@ -40,27 +46,37 @@
 #' mcmc_areas(x, regex_pars = "beta")
 #'
 #' # use one of the themes included in ggplot2
-#' mcmc_dens_overlay(x) + ggplot2::theme_gray()
+#' ggplot2::theme_set(ggplot2::theme_gray())
+#' mcmc_dens_overlay(x)
 #'
-theme_default <- function(base_size = getOption("bayesplot.base_size", 12),
-                          base_family = getOption("bayesplot.base_family", "serif")) {
-  theme_bw(base_family = base_family, base_size = base_size) +
-    theme(
-      plot.background = element_blank(),
-      panel.grid = element_blank(),
-      panel.background = element_blank(),
-      panel.border = element_blank(),
-      axis.line = element_line(size = 0.4),
-      axis.ticks = element_line(size = 0.3),
-      strip.background = element_blank(),
-      strip.text = element_text(size = rel(0.9)),
-      strip.placement = "outside",
-      # strip.background = element_rect(fill = "gray95", color = NA),
-      panel.spacing = unit(1.5, "lines"),
-      legend.position = "right",
-      legend.background = element_blank(),
-      legend.text = element_text(size = 13),
-      legend.text.align = 0,
-      legend.key = element_blank()
-    )
-}
+#' # change back to bayesplot default theme
+#' ggplot2::theme_set(bayesplot::theme_default())
+#' mcmc_dens_overlay(x)
+#'
+theme_default <-
+  function(base_size = getOption("bayesplot.base_size", 12),
+           base_family = getOption("bayesplot.base_family", "serif")) {
+
+    theme_bw(
+      base_family = base_family,
+      base_size = base_size
+    ) +
+      theme(
+        plot.background = element_blank(),
+        panel.grid = element_blank(),
+        panel.background = element_blank(),
+        panel.border = element_blank(),
+        axis.line = element_line(size = 0.4),
+        axis.ticks = element_line(size = 0.3),
+        strip.background = element_blank(),
+        strip.text = element_text(size = rel(0.9)),
+        strip.placement = "outside",
+        # strip.background = element_rect(fill = "gray95", color = NA),
+        panel.spacing = unit(1.5, "lines"),
+        legend.position = "right",
+        legend.background = element_blank(),
+        legend.text = element_text(size = 13),
+        legend.text.align = 0,
+        legend.key = element_blank()
+      )
+  }

--- a/R/helpers-gg.R
+++ b/R/helpers-gg.R
@@ -12,7 +12,7 @@ dont_expand_axes <- function() {
   coord_cartesian(expand = FALSE)
 }
 force_axes_in_facets <- function() {
-  thm <- theme_default()
+  thm <- ggplot2::theme_get()
   annotate("segment",
            x = c(-Inf, -Inf), xend = c(Inf,-Inf),
            y = c(-Inf,-Inf), yend = c(-Inf, Inf),

--- a/R/mcmc-alg-nuts.R
+++ b/R/mcmc-alg-nuts.R
@@ -184,7 +184,6 @@ mcmc_nuts_acceptance <-
     hists <- hists +
       dont_expand_y_axis(c(0.005, 0)) +
       facet_wrap(~ Parameter, scales = "free") +
-      theme_default() +
       yaxis_text(FALSE) +
       yaxis_title(FALSE) +
       yaxis_ticks(FALSE) +
@@ -198,8 +197,7 @@ mcmc_nuts_acceptance <-
         fill = get_color(ifelse(overlay_chain, "l", "m")),
         color = get_color(ifelse(overlay_chain, "lh", "mh"))
       ) +
-      labs(x = "accept_stat__", y = "lp__") +
-      theme_default()
+      labs(x = "accept_stat__", y = "lp__")
 
     if (overlay_chain) {
       hists <- hists +
@@ -258,7 +256,6 @@ mcmc_nuts_divergence <- function(x, lp, chain = NULL, ...) {
   violin_lp <- ggplot(violin_lp_data, aes_(x = ~ Value, y = ~ lp)) +
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     ylab("lp__") +
-    theme_default() +
     xaxis_title(FALSE)
 
   violin_accept_stat_data <- data.frame(divergent, as = accept_stat$Value)
@@ -266,7 +263,6 @@ mcmc_nuts_divergence <- function(x, lp, chain = NULL, ...) {
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     ylab("accept_stat__") +
     scale_y_continuous(limits = c(NA, 1.05)) +
-    theme_default() +
     xaxis_title(FALSE)
 
   div_count_label <- paste(table(divergent$Value)[[2]], "divergences")
@@ -316,7 +312,6 @@ mcmc_nuts_stepsize <- function(x, lp, chain = NULL, ...) {
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     ylab("lp__") +
     stepsize_labels +
-    theme_default() +
     xaxis_title(FALSE)
 
   violin_accept_stat_data <-
@@ -327,7 +322,6 @@ mcmc_nuts_stepsize <- function(x, lp, chain = NULL, ...) {
     ylab("accept_stat__") +
     scale_y_continuous(limits = c(NA, 1.05)) +
     stepsize_labels +
-    theme_default() +
     xaxis_title(FALSE)
 
   if (!is.null(chain)) {
@@ -364,7 +358,6 @@ mcmc_nuts_treedepth <- function(x, lp, chain = NULL, ...) {
       binwidth = 1
     ) +
     xlab("treedepth__") +
-    theme_default() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
     yaxis_ticks(FALSE)
@@ -373,16 +366,14 @@ mcmc_nuts_treedepth <- function(x, lp, chain = NULL, ...) {
   violin_lp <-
     ggplot(violin_lp_data, aes_(x = ~ factor(Value), y = ~ lp)) +
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
-    labs(x = "treedepth__", y = "lp__") +
-    theme_default()
+    labs(x = "treedepth__", y = "lp__")
 
   violin_accept_stat_data <- data.frame(treedepth, as = accept_stat$Value)
   violin_accept_stat <-
     ggplot(violin_accept_stat_data, aes_(x = ~ factor(Value), y = ~ as)) +
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     labs(x = "treedepth__", y = "accept_stat__") +
-    scale_y_continuous(breaks = c(0, 0.5, 1)) +
-    theme_default()
+    scale_y_continuous(breaks = c(0, 0.5, 1))
 
   if (overlay_chain) {
     hist_td <- hist_td +
@@ -479,7 +470,6 @@ mcmc_nuts_energy <-
       dont_expand_y_axis(c(0.005, 0)) +
       scale_x_continuous(expand = c(0.2, 0)) +
       labs(y = NULL, x = expression(E - bar(E))) +
-      theme_default() +
       space_legend_keys() +
       theme(legend.text = element_text(size = rel(1.1))) +
       yaxis_text(FALSE) +

--- a/R/mcmc-diagnostics.R
+++ b/R/mcmc-diagnostics.R
@@ -173,7 +173,6 @@ mcmc_rhat <- function(rhat, ..., size = NULL) {
     scale_color_diagnostic("rhat") +
     scale_x_continuous(breaks = brks, expand = c(0, .01)) +
     scale_y_discrete(expand = c(.025,0)) +
-    theme_default() +
     yaxis_title(FALSE) +
     yaxis_text(FALSE) +
     yaxis_ticks(FALSE)
@@ -203,7 +202,6 @@ mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL) {
     scale_fill_diagnostic("rhat") +
     labs(x = expression(hat(R)), y = NULL) +
     dont_expand_y_axis(c(0.005, 0)) +
-    theme_default() +
     yaxis_title(FALSE) +
     yaxis_text(FALSE) +
     yaxis_ticks(FALSE)
@@ -247,7 +245,6 @@ mcmc_neff <- function(ratio, ..., size = NULL) {
     scale_x_continuous(breaks = c(0.1, seq(0, 1, .25)),
                        limits = c(0, 1), expand = c(0,.01)) +
     scale_y_discrete(expand = c(.025,0)) +
-    theme_default() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
     yaxis_ticks(FALSE)
@@ -277,7 +274,6 @@ mcmc_neff_hist <- function(ratio, ..., binwidth = NULL) {
     scale_fill_diagnostic("neff") +
     labs(x = expression(N[eff]/N), y = NULL) +
     dont_expand_y_axis(c(0.005, 0)) +
-    theme_default() +
     yaxis_title(FALSE) +
     yaxis_text(FALSE) +
     yaxis_ticks(FALSE)
@@ -545,8 +541,7 @@ validate_neff_ratio <- function(ratio) {
         expand = c(0, 0)
       ) +
       labs(x = "Lag", y = "Autocorrelation") +
-      force_axes_in_facets() +
-      theme_default()
+      force_axes_in_facets()
   }
 
 # Prepare data for autocorr plot

--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -250,7 +250,6 @@ mcmc_violin <- function(x,
   }
   graph +
     dont_expand_y_axis(c(0.005, 0)) +
-    theme_default() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
     yaxis_ticks(FALSE) +
@@ -319,7 +318,6 @@ mcmc_violin <- function(x,
   graph +
     do.call("facet_wrap", facet_args) +
     dont_expand_y_axis(c(0.005, 0)) +
-    theme_default() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
     yaxis_ticks(FALSE) +

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -409,7 +409,6 @@ mcmc_areas <- function(x,
       limits = c(0.5, n_param + 1)
     ) +
     xlim(x_lim) +
-    theme_default() +
     legend_move(ifelse(color_by_rhat, "top", "none")) +
     yaxis_text(face = "bold") +
     yaxis_title(FALSE) +

--- a/R/mcmc-recover.R
+++ b/R/mcmc-recover.R
@@ -195,7 +195,6 @@ mcmc_recover_intervals <-
       ) +
       do.call("facet_wrap", facet_args) +
       labs(y = "Value", x = "Parameter", subtitle = plot_caption) +
-      theme_default() +
       theme(plot.caption = element_text(hjust = 0)) +
       xaxis_title(FALSE) +
       yaxis_title(FALSE)
@@ -269,8 +268,7 @@ mcmc_recover_scatter <-
         alpha = alpha
       ) +
       do.call("facet_wrap", facet_args) +
-      labs(y = "Estimated", x = "True") +
-      theme_default()
+      labs(y = "Estimated", x = "True")
 
     if (length(unique(batch)) == 1) {
       g <- ggplot_build(graph)
@@ -330,7 +328,6 @@ mcmc_recover_hist <-
       scale_color_manual("", values = get_color("dh")) +
       guides(color = guide_legend(), fill = guide_legend(order = 1)) +
       dont_expand_y_axis() +
-      theme_default() +
       reduce_legend_spacing(0.25) +
       xaxis_title(FALSE) +
       yaxis_text(FALSE) +

--- a/R/mcmc-scatterplots.R
+++ b/R/mcmc-scatterplots.R
@@ -610,9 +610,7 @@ pairs_condition <- function(chains = NULL, draws = NULL, nuts = NULL) {
       )
   }
 
-  graph +
-    labs(x = parnames[1], y = parnames[2]) +
-    theme_default()
+  graph + labs(x = parnames[1], y = parnames[2])
 }
 
 

--- a/R/mcmc-traces.R
+++ b/R/mcmc-traces.R
@@ -282,7 +282,6 @@ mcmc_trace_highlight <-
   graph +
     do.call("facet_wrap", facet_args) +
     scale_x_continuous(breaks = pretty) +
-    theme_default() +
     legend_move(ifelse(nlevels(data$Chain) > 1, "right", "none")) +
     xaxis_title(FALSE) +
     yaxis_title(FALSE)

--- a/R/ppc-discrete.R
+++ b/R/ppc-discrete.R
@@ -270,9 +270,7 @@ ppc_rootogram <- function(y,
   if (style == "standing")
     graph <- graph + dont_expand_y_axis()
 
-  graph +
-    theme_default() +
-    reduce_legend_spacing(0.25)
+  graph + reduce_legend_spacing(0.25)
 }
 
 
@@ -386,8 +384,6 @@ ppc_bars_yrep_data <- function(y, yrep, probs, freq = TRUE, group = NULL) {
     graph <- graph + expand_limits(y = 1.05 * y_axis_max)
   }
 
-  graph +
-    theme_default() +
-    reduce_legend_spacing(0.25)
+  graph + reduce_legend_spacing(0.25)
 }
 

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -115,7 +115,6 @@ ppc_hist <- function(y, yrep, ...,
     facet_wrap_parsed("rep_id") +
     force_axes_in_facets() +
     dont_expand_y_axis() +
-    theme_default() +
     space_legend_keys() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
@@ -151,7 +150,6 @@ ppc_boxplot <- function(y, yrep, ..., notch = TRUE, size = 0.5, alpha = 1) {
     ) +
     scale_fill_ppc_dist() +
     scale_color_ppc_dist() +
-    theme_default() +
     yaxis_title(FALSE) +
     xaxis_ticks(FALSE) +
     xaxis_text(FALSE) +
@@ -182,7 +180,6 @@ ppc_freqpoly <- function(y, yrep, ...,
     facet_wrap_parsed("rep_id") +
     force_axes_in_facets() +
     dont_expand_y_axis() +
-    theme_default() +
     space_legend_keys() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
@@ -228,7 +225,6 @@ ppc_freqpoly_grouped <-
       scale_color_ppc_dist() +
       dont_expand_y_axis(c(0.005, 0)) +
       force_axes_in_facets() +
-      theme_default() +
       space_legend_keys() +
       xaxis_title(FALSE) +
       yaxis_text(FALSE) +
@@ -263,7 +259,6 @@ ppc_dens <- function(y, yrep, ...,
     facet_wrap_parsed("rep_id") +
     force_axes_in_facets() +
     dont_expand_y_axis() +
-    theme_default() +
     space_legend_keys() +
     yaxis_text(FALSE) +
     yaxis_title(FALSE) +
@@ -304,7 +299,6 @@ ppc_dens_overlay <- function(y, yrep, ...,
     scale_color_ppc_dist() +
     xlab(y_label()) +
     dont_expand_axes() +
-    theme_default() +
     yaxis_title(FALSE) +
     xaxis_title(FALSE) +
     yaxis_text(FALSE) +
@@ -342,7 +336,6 @@ ppc_ecdf_overlay <- function(y, yrep, ...,
     scale_color_ppc_dist() +
     xlab(y_label()) +
     scale_y_continuous(breaks = c(0, 0.5, 1)) +
-    theme_default() +
     yaxis_title(FALSE) +
     xaxis_title(FALSE) +
     yaxis_ticks(FALSE)
@@ -421,7 +414,6 @@ ppc_violin_grouped <- function(y,
     scale_fill_ppc_dist(values = c(NA, get_color("l"))) +
     scale_color_ppc_dist() +
     labs(x = "Group", y = yrep_label()) +
-    theme_default() +
     yaxis_title(FALSE) +
     xaxis_title(FALSE)
 }

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -148,7 +148,6 @@ ppc_error_hist <-
       xlab(expression(italic(y) - italic(y)[rep])) +
       dont_expand_y_axis() +
       force_axes_in_facets() +
-      theme_default() +
       yaxis_title(FALSE) +
       yaxis_text(FALSE) +
       yaxis_ticks(FALSE) +
@@ -186,7 +185,6 @@ ppc_error_hist_grouped <-
       xlab(expression(italic(y) - italic(y)[rep])) +
       dont_expand_y_axis(c(0.005, 0)) +
       force_axes_in_facets() +
-      theme_default() +
       yaxis_text(FALSE) +
       yaxis_ticks(FALSE) +
       yaxis_title(FALSE) +
@@ -218,8 +216,7 @@ ppc_error_scatter <-
           size = size,
           alpha = alpha,
           abline = FALSE
-        ) +
-          theme_default()
+        )
       )
     }
 
@@ -242,7 +239,6 @@ ppc_error_scatter <-
         # labeller = label_bquote(italic(y) - italic(y)[rep](.(rep_id)))
       ) +
       force_axes_in_facets() +
-      theme_default() +
       facet_text(FALSE) +
       facet_bg(FALSE)
   }
@@ -275,8 +271,7 @@ ppc_error_scatter_avg <-
       alpha = alpha,
       size = size,
       abline = FALSE
-    ) +
-      theme_default()
+    )
   }
 
 #' @rdname PPC-errors
@@ -304,8 +299,7 @@ ppc_error_scatter_avg_vs_x <-
       alpha = alpha,
       size = size,
       abline = FALSE
-    ) +
-      theme_default()
+    )
   }
 
 
@@ -392,7 +386,6 @@ ppc_error_binned <- function(y, yrep, ..., size = 1, alpha = 0.25) {
 
   graph +
     force_axes_in_facets() +
-    theme_default() +
     facet_text(FALSE) +
     facet_bg(FALSE)
 }

--- a/R/ppc-intervals.R
+++ b/R/ppc-intervals.R
@@ -350,7 +350,6 @@ label_x <- function(x) {
         do.call("facet_wrap", facet_args)
     }
     graph +
-      labs(y = NULL, x = x_lab %||% expression(italic(x))) +
-      theme_default()
+      labs(y = NULL, x = x_lab %||% expression(italic(x)))
   }
 

--- a/R/ppc-loo.R
+++ b/R/ppc-loo.R
@@ -144,8 +144,7 @@ ppc_loo_pit <-
 
     graph +
       coord_fixed(xlim = xylim, ylim = xylim) +
-      labs(y = y_lab, x = x_lab) +
-      theme_default()
+      labs(y = y_lab, x = x_lab)
   }
 
 

--- a/R/ppc-scatterplots.R
+++ b/R/ppc-scatterplots.R
@@ -84,7 +84,6 @@ ppc_scatter <-
     graph +
       facet_wrap_parsed("rep_id") +
       force_axes_in_facets() +
-      theme_default() +
       facet_text(FALSE) +
       facet_bg(FALSE)
   }
@@ -112,8 +111,7 @@ ppc_scatter_avg <-
       x_lab = yrep_avg_label(),
       alpha = alpha,
       size = size
-    ) +
-      theme_default()
+    )
   }
 
 #' @export
@@ -150,8 +148,7 @@ ppc_scatter_avg_grouped <-
         y = y_label(),
         x = yrep_avg_label()
       ) +
-      facet_wrap("group", scales = "free") +
-      theme_default()
+      facet_wrap("group", scales = "free")
   }
 
 

--- a/R/ppc-test-statistics.R
+++ b/R/ppc-test-statistics.R
@@ -114,7 +114,6 @@ ppc_stat <-
         )
       ) +
       dont_expand_y_axis() +
-      theme_default() +
       no_legend_spacing() +
       xaxis_title(FALSE) +
       yaxis_text(FALSE) +
@@ -167,7 +166,6 @@ ppc_stat_grouped <-
         )
       ) +
       dont_expand_y_axis() +
-      theme_default() +
       no_legend_spacing() +
       xaxis_title(FALSE) +
       yaxis_text(FALSE) +
@@ -216,7 +214,6 @@ ppc_stat_freqpoly_grouped <-
         labels = c(yrep = Tyrep_label(), y = Ty_label())
       ) +
       dont_expand_y_axis(c(0.005, 0)) +
-      theme_default() +
       xaxis_title(FALSE) +
       yaxis_text(FALSE) +
       yaxis_ticks(FALSE) +
@@ -287,8 +284,7 @@ ppc_stat_2d <- function(y, yrep, stat = c("mean", "sd"), ...,
       values = setNames(get_color(c("dh", "lh")), c("y", "yrep")),
       labels = c(y = Ty_label(), yrep = Tyrep_label())
     ) +
-    labs(x = stat_labs[1], y = stat_labs[2]) +
-    theme_default()
+    labs(x = stat_labs[1], y = stat_labs[2])
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,5 @@
 .onAttach <- function(...) {
   ver <- utils::packageVersion("bayesplot")
   packageStartupMessage("This is bayesplot version ", ver)
+  ggplot2::theme_set(bayesplot::theme_default())
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,8 @@
 .onAttach <- function(...) {
   ver <- utils::packageVersion("bayesplot")
-  packageStartupMessage("This is bayesplot version ", ver)
+  packageStartupMessage(
+    "This is bayesplot version ", ver, ". ",
+    "Setting ggplot2 theme to bayesplot::theme_default()."
+  )
   ggplot2::theme_set(bayesplot::theme_default())
 }

--- a/man/theme_default.Rd
+++ b/man/theme_default.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/bayesplot-ggplot-themes.R
 \name{theme_default}
 \alias{theme_default}
-\title{Default plotting theme}
+\title{Default bayesplot plotting theme}
 \usage{
 theme_default(base_size = getOption("bayesplot.base_size", 12),
   base_family = getOption("bayesplot.base_family", "serif"))
@@ -19,11 +19,18 @@ A ggplot \link[ggplot2]{theme} object.
 }
 \description{
 The \code{\link{theme_default}} function returns the default ggplot
-\link{theme} used by the \pkg{bayesplot} plotting functions. Many of the
-individual plotting functions also make small alterations to the default
-theme using the convenience functions documented at \link{bayesplot-helpers}.
-To use a different theme simply add that theme to the ggplot objects created
-by the \pkg{bayesplot} plotting functions (see \strong{Examples}, below).
+\link{theme} used by the \pkg{bayesplot} plotting functions.
+After loading the \pkg{bayesplot} package, this theme will be the default for
+\emph{all} graphs made with \pkg{ggplot2}. See the \strong{Details} section,
+below.
+}
+\details{
+After loading \pkg{bayesplot}, if you subsequently change the
+default \pkg{ggplot2} theme (i.e., by calling
+\code{\link[ggplot2]{theme_set}} or loading a different package that changes
+the theme) then \pkg{bayesplot} will use that theme instead. To change back
+to the default \pkg{bayesplot} theme use \code{bayesplot::theme_default()} as
+the argument to \code{\link[ggplot2]{theme_set}}.
 }
 \examples{
 thm <- theme_default()
@@ -46,7 +53,12 @@ options(bayesplot.base_size = 12,
 mcmc_areas(x, regex_pars = "beta")
 
 # use one of the themes included in ggplot2
-mcmc_dens_overlay(x) + ggplot2::theme_gray()
+ggplot2::theme_set(ggplot2::theme_gray())
+mcmc_dens_overlay(x)
+
+# change back to bayesplot default theme
+ggplot2::theme_set(bayesplot::theme_default())
+mcmc_dens_overlay(x)
 
 }
 \seealso{


### PR DESCRIPTION
Set `theme_default()` as the default ggplot theme when loading __bayesplot__ instead of hardcoding it in each function. This makes changing the theme using `ggplot2::theme_set` possible.

See issue #87 for details. 