### PR TITLE
Update testthat and covr in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ r:
 cache: packages
 
 r_github_packages:
-  - hadley/testthat
-  - jimhester/covr
+  - r-lib/covr
 
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     rstantools (>= 1.4.0),
     scales,
     shinystan (>= 2.3.0),
-    testthat,
+    testthat (>= 2.0.0),
     vdiffr
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr


### PR DESCRIPTION
Now that testthat v2.0.0 is on CRAN (and the bug in test_path is fixed) this PR adds testthat (>= 2.0.0) to DESCRIPTION and removes it from r_github_packages in the travis file. It also replaces jimhester/covr with r-lib/covr. 