### PR TITLE
Pass 'breaks' to geom_histogram

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ title to the plot, for example. (#143)
 
 * `ppc_ecdf_overlay()` gains an argument `discrete`, which is `FALSE` by default, but can be used to make the Geom more appropriate for discrete data. (#145)
 
-* `mcmc_hist()` gains a `breaks` argument that can be used as an alternative to
+* Histograms gain a `breaks` argument that can be used as an alternative to
 `binwidth`.
 
 # bayesplot 1.5.0

--- a/R/mcmc-diagnostics-nuts.R
+++ b/R/mcmc-diagnostics-nuts.R
@@ -139,7 +139,8 @@ NULL
 
 #' @rdname MCMC-nuts
 #' @export
-#' @template args-hist
+#' @param binwidth An optional value passed to
+#'   \code{\link[ggplot2]{geom_histogram}} to override the default binwidth.
 #'
 mcmc_nuts_acceptance <-
   function(x,

--- a/R/mcmc-diagnostics.R
+++ b/R/mcmc-diagnostics.R
@@ -173,7 +173,7 @@ mcmc_rhat <- function(rhat, ..., size = NULL) {
 
 #' @rdname MCMC-diagnostics
 #' @export
-mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL) {
+mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL, breaks = NULL) {
   check_ignored_arguments(...)
   data <- mcmc_rhat_data(rhat)
 
@@ -186,7 +186,9 @@ mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL) {
     geom_histogram(
       size = .25,
       na.rm = TRUE,
-      binwidth = binwidth) +
+      binwidth = binwidth,
+      breaks = breaks
+    ) +
     scale_color_diagnostic("rhat") +
     scale_fill_diagnostic("rhat") +
     labs(x = expression(hat(R)), y = NULL) +
@@ -247,7 +249,7 @@ mcmc_neff <- function(ratio, ..., size = NULL) {
 
 #' @rdname MCMC-diagnostics
 #' @export
-mcmc_neff_hist <- function(ratio, ..., binwidth = NULL) {
+mcmc_neff_hist <- function(ratio, ..., binwidth = NULL, breaks = NULL) {
   check_ignored_arguments(...)
   data <- mcmc_neff_data(ratio)
 
@@ -260,7 +262,8 @@ mcmc_neff_hist <- function(ratio, ..., binwidth = NULL) {
     geom_histogram(
       size = .25,
       na.rm = TRUE,
-      binwidth = binwidth) +
+      binwidth = binwidth,
+      breaks = breaks) +
     scale_color_diagnostic("neff") +
     scale_fill_diagnostic("neff") +
     labs(x = expression(N[eff]/N), y = NULL) +

--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -104,8 +104,6 @@ NULL
 #' @export
 #' @template args-hist
 #' @template args-hist-freq
-#' @param breaks Passed to \code{\link[ggplot2]{geom_histogram}} as an
-#'   alternative to binwidth.
 #'
 mcmc_hist <- function(x,
                       pars = character(),

--- a/R/mcmc-recover.R
+++ b/R/mcmc-recover.R
@@ -291,7 +291,8 @@ mcmc_recover_hist <-
            true,
            facet_args = list(),
            ...,
-           binwidth = NULL) {
+           binwidth = NULL,
+           breaks = NULL) {
 
     check_ignored_arguments(...)
     x <- merge_chains(prepare_mcmc_array(x))
@@ -314,7 +315,8 @@ mcmc_recover_hist <-
         data = hist_data,
         color = get_color("lh"),
         size = .25,
-        binwidth = binwidth
+        binwidth = binwidth,
+        breaks = breaks
       ) +
       geom_vline(
         aes_(xintercept = ~ True, color = "True"),

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -121,27 +121,37 @@ ppc_data <- function(y, yrep, group = NULL) {
 
 #' @rdname PPC-distributions
 #' @export
-ppc_hist <- function(y, yrep, ..., binwidth = NULL, freq = TRUE) {
-  check_ignored_arguments(...)
-  data <- ppc_data(y, yrep)
-  aes_list <- set_hist_aes(freq, fill = ~ is_y_label, color = ~ is_y_label)
+ppc_hist <-
+  function(y,
+           yrep,
+           ...,
+           binwidth = NULL,
+           breaks = NULL,
+           freq = TRUE) {
+    check_ignored_arguments(...)
+    data <- ppc_data(y, yrep)
+    aes_list <- set_hist_aes(freq, fill = ~ is_y_label, color = ~ is_y_label)
 
-  ggplot(data) +
-    aes_list +
-    geom_histogram(size = 0.25, binwidth = binwidth) +
-    scale_fill_ppc_dist() +
-    scale_color_ppc_dist() +
-    facet_wrap_parsed("rep_label") +
-    force_axes_in_facets() +
-    dont_expand_y_axis() +
-    space_legend_keys() +
-    yaxis_text(FALSE) +
-    yaxis_title(FALSE) +
-    yaxis_ticks(FALSE) +
-    xaxis_title(FALSE) +
-    facet_text(FALSE) +
-    facet_bg(FALSE)
-}
+    ggplot(data) +
+      aes_list +
+      geom_histogram(
+        size = 0.25,
+        binwidth = binwidth,
+        breaks = breaks
+      ) +
+      scale_fill_ppc_dist() +
+      scale_color_ppc_dist() +
+      facet_wrap_parsed("rep_label") +
+      force_axes_in_facets() +
+      dont_expand_y_axis() +
+      space_legend_keys() +
+      yaxis_text(FALSE) +
+      yaxis_title(FALSE) +
+      yaxis_ticks(FALSE) +
+      xaxis_title(FALSE) +
+      facet_text(FALSE) +
+      facet_bg(FALSE)
+  }
 
 
 

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -121,6 +121,7 @@ ppc_error_hist <-
            yrep,
            ...,
            binwidth = NULL,
+           breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
 
@@ -143,7 +144,8 @@ ppc_error_hist <-
         fill = get_color("l"),
         color = get_color("lh"),
         size = 0.25,
-        binwidth = binwidth
+        binwidth = binwidth,
+        breaks = breaks
       ) +
       xlab(expression(italic(y) - italic(y)[rep])) +
       dont_expand_y_axis() +
@@ -166,6 +168,7 @@ ppc_error_hist_grouped <-
            group,
            ...,
            binwidth = NULL,
+           breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
 
@@ -179,7 +182,8 @@ ppc_error_hist_grouped <-
         fill = get_color("l"),
         color = get_color("lh"),
         size = 0.25,
-        binwidth = binwidth
+        binwidth = binwidth,
+        breaks = breaks
       ) +
       facet_grid(rep_id ~ group, scales = "free") +
       xlab(expression(italic(y) - italic(y)[rep])) +

--- a/R/ppc-test-statistics.R
+++ b/R/ppc-test-statistics.R
@@ -82,6 +82,7 @@ ppc_stat <-
            stat = "mean",
            ...,
            binwidth = NULL,
+           breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
 
@@ -98,7 +99,8 @@ ppc_stat <-
         color = get_color("lh"),
         size = .25,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        breaks = breaks
       ) +
       geom_vline(
         data = data.frame(Ty = T_y),
@@ -134,6 +136,7 @@ ppc_stat_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
 
@@ -154,7 +157,8 @@ ppc_stat_grouped <-
         color = get_color("lh"),
         size = .25,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        breaks = breaks
       ) +
       geom_vline(
         data = plot_data[is_y, , drop = FALSE],

--- a/man-roxygen/args-hist.R
+++ b/man-roxygen/args-hist.R
@@ -1,2 +1,6 @@
-#' @param binwidth An optional value used as the \code{binwidth} argument to
-#'   \code{\link[ggplot2]{geom_histogram}} to override the default binwidth.
+#' @param binwidth Passed to \code{\link[ggplot2]{geom_histogram}} to override
+#'   the default binwidth.
+#'
+#' @param breaks Passed to \code{\link[ggplot2]{geom_histogram}} as an
+#'   alternative to \code{binwidth}.
+#'

--- a/man-roxygen/args-transformations.R
+++ b/man-roxygen/args-transformations.R
@@ -15,3 +15,7 @@
 #'   If a function itself is specified (e.g. \code{log} or \code{function(x)
 #'   log(x)}) then \code{"t"} is used in the new parameter label to indicate
 #'   that the parameter is transformed (e.g. \code{"t(sigma)"}).
+#'
+#'   Note: due to partial argument matching \code{transformations} can be
+#'   abbreviated for convenience in interactive use (e.g., \code{transform},
+#'   \code{trans}, etc.).

--- a/man/MCMC-diagnostics.Rd
+++ b/man/MCMC-diagnostics.Rd
@@ -14,13 +14,13 @@
 \usage{
 mcmc_rhat(rhat, ..., size = NULL)
 
-mcmc_rhat_hist(rhat, ..., binwidth = NULL)
+mcmc_rhat_hist(rhat, ..., binwidth = NULL, breaks = NULL)
 
 mcmc_rhat_data(rhat, ...)
 
 mcmc_neff(ratio, ..., size = NULL)
 
-mcmc_neff_hist(ratio, ..., binwidth = NULL)
+mcmc_neff_hist(ratio, ..., binwidth = NULL, breaks = NULL)
 
 mcmc_neff_data(ratio, ...)
 
@@ -39,8 +39,11 @@ mcmc_acf_bar(x, pars = character(), regex_pars = character(),
 default size (for \code{mcmc_rhat}, \code{mcmc_neff}) or
 \code{\link[ggplot2]{geom_line}}'s default size (for \code{mcmc_acf}).}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
+alternative to \code{binwidth}.}
 
 \item{ratio}{A vector of \emph{ratios} of effective sample size estimates to
 total sample size. See \code{\link{neff_ratio}}.}

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -52,22 +52,26 @@ parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
 \item{transformations}{Optionally, transformations to apply to parameters
-before plotting. If \code{transformations} is a function or a single string
-naming a function then that function will be used to transform all
-parameters. To apply transformations to particular parameters, the
-\code{transformations} argument can be a named list with length equal to
-the number of parameters to be transformed. Currently only univariate
-transformations of scalar parameters can be specified (multivariate
-transformations will be implemented in a future release). If
-\code{transformations} is a list, the name of each list element should be a
-parameter name and the content of each list element should be a function
-(or any item to match as a function via \code{\link{match.fun}}, e.g. a
-string naming a function). If a function is specified by its name as a
-string (e.g. \code{"log"}), then it can be used to construct a new
-parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
-If a function itself is specified (e.g. \code{log} or \code{function(x)
-log(x)}) then \code{"t"} is used in the new parameter label to indicate
-that the parameter is transformed (e.g. \code{"t(sigma)"}).}
+  before plotting. If \code{transformations} is a function or a single string
+  naming a function then that function will be used to transform all
+  parameters. To apply transformations to particular parameters, the
+  \code{transformations} argument can be a named list with length equal to
+  the number of parameters to be transformed. Currently only univariate
+  transformations of scalar parameters can be specified (multivariate
+  transformations will be implemented in a future release). If
+  \code{transformations} is a list, the name of each list element should be a
+  parameter name and the content of each list element should be a function
+  (or any item to match as a function via \code{\link{match.fun}}, e.g. a
+  string naming a function). If a function is specified by its name as a
+  string (e.g. \code{"log"}), then it can be used to construct a new
+  parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+  If a function itself is specified (e.g. \code{log} or \code{function(x)
+  log(x)}) then \code{"t"} is used in the new parameter label to indicate
+  that the parameter is transformed (e.g. \code{"t(sigma)"}).
+
+  Note: due to partial argument matching \code{transformations} can be
+  abbreviated for convenience in interactive use (e.g., \code{transform},
+  \code{trans}, etc.).}
 
 \item{facet_args}{A named list of arguments (other than \code{facets}) passed
 to \code{\link[ggplot2]{facet_wrap}} or \code{\link[ggplot2]{facet_grid}}
@@ -75,11 +79,11 @@ to control faceting.}
 
 \item{...}{Currently ignored.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
-alternative to binwidth.}
+alternative to \code{binwidth}.}
 
 \item{freq}{For histograms, \code{freq=TRUE} (the default) puts count on the
 y-axis. Setting \code{freq=FALSE} puts density on the y-axis. (For many

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -50,22 +50,26 @@ parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
 \item{transformations}{Optionally, transformations to apply to parameters
-before plotting. If \code{transformations} is a function or a single string
-naming a function then that function will be used to transform all
-parameters. To apply transformations to particular parameters, the
-\code{transformations} argument can be a named list with length equal to
-the number of parameters to be transformed. Currently only univariate
-transformations of scalar parameters can be specified (multivariate
-transformations will be implemented in a future release). If
-\code{transformations} is a list, the name of each list element should be a
-parameter name and the content of each list element should be a function
-(or any item to match as a function via \code{\link{match.fun}}, e.g. a
-string naming a function). If a function is specified by its name as a
-string (e.g. \code{"log"}), then it can be used to construct a new
-parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
-If a function itself is specified (e.g. \code{log} or \code{function(x)
-log(x)}) then \code{"t"} is used in the new parameter label to indicate
-that the parameter is transformed (e.g. \code{"t(sigma)"}).}
+  before plotting. If \code{transformations} is a function or a single string
+  naming a function then that function will be used to transform all
+  parameters. To apply transformations to particular parameters, the
+  \code{transformations} argument can be a named list with length equal to
+  the number of parameters to be transformed. Currently only univariate
+  transformations of scalar parameters can be specified (multivariate
+  transformations will be implemented in a future release). If
+  \code{transformations} is a list, the name of each list element should be a
+  parameter name and the content of each list element should be a function
+  (or any item to match as a function via \code{\link{match.fun}}, e.g. a
+  string naming a function). If a function is specified by its name as a
+  string (e.g. \code{"log"}), then it can be used to construct a new
+  parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+  If a function itself is specified (e.g. \code{log} or \code{function(x)
+  log(x)}) then \code{"t"} is used in the new parameter label to indicate
+  that the parameter is transformed (e.g. \code{"t(sigma)"}).
+
+  Note: due to partial argument matching \code{transformations} can be
+  abbreviated for convenience in interactive use (e.g., \code{transform},
+  \code{trans}, etc.).}
 
 \item{...}{Currently unused.}
 

--- a/man/MCMC-nuts.Rd
+++ b/man/MCMC-nuts.Rd
@@ -40,7 +40,7 @@ is not used by \code{mcmc_nuts_energy}.}
 
 \item{...}{Currently ignored.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
+\item{binwidth}{An optional value passed to
 \code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
 
 \item{alpha}{For \code{mcmc_nuts_energy} only, the transparency (alpha) level

--- a/man/MCMC-parcoord.Rd
+++ b/man/MCMC-parcoord.Rd
@@ -30,22 +30,26 @@ parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
 \item{transformations}{Optionally, transformations to apply to parameters
-before plotting. If \code{transformations} is a function or a single string
-naming a function then that function will be used to transform all
-parameters. To apply transformations to particular parameters, the
-\code{transformations} argument can be a named list with length equal to
-the number of parameters to be transformed. Currently only univariate
-transformations of scalar parameters can be specified (multivariate
-transformations will be implemented in a future release). If
-\code{transformations} is a list, the name of each list element should be a
-parameter name and the content of each list element should be a function
-(or any item to match as a function via \code{\link{match.fun}}, e.g. a
-string naming a function). If a function is specified by its name as a
-string (e.g. \code{"log"}), then it can be used to construct a new
-parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
-If a function itself is specified (e.g. \code{log} or \code{function(x)
-log(x)}) then \code{"t"} is used in the new parameter label to indicate
-that the parameter is transformed (e.g. \code{"t(sigma)"}).}
+  before plotting. If \code{transformations} is a function or a single string
+  naming a function then that function will be used to transform all
+  parameters. To apply transformations to particular parameters, the
+  \code{transformations} argument can be a named list with length equal to
+  the number of parameters to be transformed. Currently only univariate
+  transformations of scalar parameters can be specified (multivariate
+  transformations will be implemented in a future release). If
+  \code{transformations} is a list, the name of each list element should be a
+  parameter name and the content of each list element should be a function
+  (or any item to match as a function via \code{\link{match.fun}}, e.g. a
+  string naming a function). If a function is specified by its name as a
+  string (e.g. \code{"log"}), then it can be used to construct a new
+  parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+  If a function itself is specified (e.g. \code{log} or \code{function(x)
+  log(x)}) then \code{"t"} is used in the new parameter label to indicate
+  that the parameter is transformed (e.g. \code{"t(sigma)"}).
+
+  Note: due to partial argument matching \code{transformations} can be
+  abbreviated for convenience in interactive use (e.g., \code{transform},
+  \code{trans}, etc.).}
 
 \item{...}{Currently ignored.}
 

--- a/man/MCMC-recover.Rd
+++ b/man/MCMC-recover.Rd
@@ -15,7 +15,8 @@ mcmc_recover_scatter(x, true, batch = rep(1, length(true)),
   facet_args = list(), ..., point_est = c("median", "mean"), size = 3,
   alpha = 1)
 
-mcmc_recover_hist(x, true, facet_args = list(), ..., binwidth = NULL)
+mcmc_recover_hist(x, true, facet_args = list(), ..., binwidth = NULL,
+  breaks = NULL)
 }
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
@@ -55,8 +56,11 @@ default), \code{"mean"}, or \code{"none"}.}
 \item{size, alpha}{Passed to \code{\link[ggplot2]{geom_point}} to control the
 appearance of plotted points.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
+alternative to \code{binwidth}.}
 }
 \value{
 A ggplot object that can be further customized using the

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -47,22 +47,26 @@ parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
 \item{transformations}{Optionally, transformations to apply to parameters
-before plotting. If \code{transformations} is a function or a single string
-naming a function then that function will be used to transform all
-parameters. To apply transformations to particular parameters, the
-\code{transformations} argument can be a named list with length equal to
-the number of parameters to be transformed. Currently only univariate
-transformations of scalar parameters can be specified (multivariate
-transformations will be implemented in a future release). If
-\code{transformations} is a list, the name of each list element should be a
-parameter name and the content of each list element should be a function
-(or any item to match as a function via \code{\link{match.fun}}, e.g. a
-string naming a function). If a function is specified by its name as a
-string (e.g. \code{"log"}), then it can be used to construct a new
-parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
-If a function itself is specified (e.g. \code{log} or \code{function(x)
-log(x)}) then \code{"t"} is used in the new parameter label to indicate
-that the parameter is transformed (e.g. \code{"t(sigma)"}).}
+  before plotting. If \code{transformations} is a function or a single string
+  naming a function then that function will be used to transform all
+  parameters. To apply transformations to particular parameters, the
+  \code{transformations} argument can be a named list with length equal to
+  the number of parameters to be transformed. Currently only univariate
+  transformations of scalar parameters can be specified (multivariate
+  transformations will be implemented in a future release). If
+  \code{transformations} is a list, the name of each list element should be a
+  parameter name and the content of each list element should be a function
+  (or any item to match as a function via \code{\link{match.fun}}, e.g. a
+  string naming a function). If a function is specified by its name as a
+  string (e.g. \code{"log"}), then it can be used to construct a new
+  parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+  If a function itself is specified (e.g. \code{log} or \code{function(x)
+  log(x)}) then \code{"t"} is used in the new parameter label to indicate
+  that the parameter is transformed (e.g. \code{"t(sigma)"}).
+
+  Note: due to partial argument matching \code{transformations} can be
+  abbreviated for convenience in interactive use (e.g., \code{transform},
+  \code{trans}, etc.).}
 
 \item{...}{Currently ignored.}
 

--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -32,22 +32,26 @@ parameter selection. Can be specified instead of \code{pars} or in addition
 to \code{pars}.}
 
 \item{transformations}{Optionally, transformations to apply to parameters
-before plotting. If \code{transformations} is a function or a single string
-naming a function then that function will be used to transform all
-parameters. To apply transformations to particular parameters, the
-\code{transformations} argument can be a named list with length equal to
-the number of parameters to be transformed. Currently only univariate
-transformations of scalar parameters can be specified (multivariate
-transformations will be implemented in a future release). If
-\code{transformations} is a list, the name of each list element should be a
-parameter name and the content of each list element should be a function
-(or any item to match as a function via \code{\link{match.fun}}, e.g. a
-string naming a function). If a function is specified by its name as a
-string (e.g. \code{"log"}), then it can be used to construct a new
-parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
-If a function itself is specified (e.g. \code{log} or \code{function(x)
-log(x)}) then \code{"t"} is used in the new parameter label to indicate
-that the parameter is transformed (e.g. \code{"t(sigma)"}).}
+  before plotting. If \code{transformations} is a function or a single string
+  naming a function then that function will be used to transform all
+  parameters. To apply transformations to particular parameters, the
+  \code{transformations} argument can be a named list with length equal to
+  the number of parameters to be transformed. Currently only univariate
+  transformations of scalar parameters can be specified (multivariate
+  transformations will be implemented in a future release). If
+  \code{transformations} is a list, the name of each list element should be a
+  parameter name and the content of each list element should be a function
+  (or any item to match as a function via \code{\link{match.fun}}, e.g. a
+  string naming a function). If a function is specified by its name as a
+  string (e.g. \code{"log"}), then it can be used to construct a new
+  parameter label for the appropriate parameter (e.g. \code{"log(sigma)"}).
+  If a function itself is specified (e.g. \code{log} or \code{function(x)
+  log(x)}) then \code{"t"} is used in the new parameter label to indicate
+  that the parameter is transformed (e.g. \code{"t(sigma)"}).
+
+  Note: due to partial argument matching \code{transformations} can be
+  abbreviated for convenience in interactive use (e.g., \code{transform},
+  \code{trans}, etc.).}
 
 \item{facet_args}{A named list of arguments (other than \code{facets}) passed
 to \code{\link[ggplot2]{facet_wrap}} or \code{\link[ggplot2]{facet_grid}}

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -15,7 +15,7 @@
 \usage{
 ppc_data(y, yrep, group = NULL)
 
-ppc_hist(y, yrep, ..., binwidth = NULL, freq = TRUE)
+ppc_hist(y, yrep, ..., binwidth = NULL, breaks = NULL, freq = TRUE)
 
 ppc_boxplot(y, yrep, ..., notch = TRUE, size = 0.5, alpha = 1)
 
@@ -54,8 +54,11 @@ pertaining to the corresponding value of \code{y}.}
 
 \item{...}{Currently unused.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
+alternative to \code{binwidth}.}
 
 \item{freq}{For histograms, \code{freq=TRUE} (the default) puts count on the
 y-axis. Setting \code{freq=FALSE} puts density on the y-axis. (For many

--- a/man/PPC-errors.Rd
+++ b/man/PPC-errors.Rd
@@ -10,9 +10,10 @@
 \alias{ppc_error_binned}
 \title{PPC errors}
 \usage{
-ppc_error_hist(y, yrep, ..., binwidth = NULL, freq = TRUE)
+ppc_error_hist(y, yrep, ..., binwidth = NULL, breaks = NULL, freq = TRUE)
 
-ppc_error_hist_grouped(y, yrep, group, ..., binwidth = NULL, freq = TRUE)
+ppc_error_hist_grouped(y, yrep, group, ..., binwidth = NULL, breaks = NULL,
+  freq = TRUE)
 
 ppc_error_scatter(y, yrep, ..., size = 2.5, alpha = 0.8)
 
@@ -35,8 +36,11 @@ instructions.}
 
 \item{...}{Currently unused.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
+alternative to \code{binwidth}.}
 
 \item{freq}{For histograms, \code{freq=TRUE} (the default) puts count on the
 y-axis. Setting \code{freq=FALSE} puts density on the y-axis. (For many

--- a/man/PPC-test-statistics.Rd
+++ b/man/PPC-test-statistics.Rd
@@ -8,10 +8,11 @@
 \alias{ppc_stat_2d}
 \title{PPC test statistics}
 \usage{
-ppc_stat(y, yrep, stat = "mean", ..., binwidth = NULL, freq = TRUE)
+ppc_stat(y, yrep, stat = "mean", ..., binwidth = NULL, breaks = NULL,
+  freq = TRUE)
 
 ppc_stat_grouped(y, yrep, group, stat = "mean", ..., facet_args = list(),
-  binwidth = NULL, freq = TRUE)
+  binwidth = NULL, breaks = NULL, freq = TRUE)
 
 ppc_stat_freqpoly_grouped(y, yrep, group, stat = "mean", ...,
   facet_args = list(), binwidth = NULL, freq = TRUE)
@@ -38,8 +39,11 @@ functions) then generic naming is used in the legend.}
 
 \item{...}{Currently unused.}
 
-\item{binwidth}{An optional value used as the \code{binwidth} argument to
-\code{\link[ggplot2]{geom_histogram}} to override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2]{geom_histogram}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2]{geom_histogram}} as an
+alternative to \code{binwidth}.}
 
 \item{freq}{For histograms, \code{freq=TRUE} (the default) puts count on the
 y-axis. Setting \code{freq=FALSE} puts density on the y-axis. (For many


### PR DESCRIPTION
This PR just adds a `breaks` argument to histograms that can be used as an alternative to `binwidth`. Turns out to be useful sometimes. 