### PR TITLE
add grouped PPC example for facet_relabel_gg

### DIFF
--- a/R/bayesplot-helpers.R
+++ b/R/bayesplot-helpers.R
@@ -234,6 +234,8 @@
 #' facet_vars(p4)
 #'
 #' # relabeling facets in grouped PPC plots
+#' pgroup <- ppc_scatter_avg_grouped(example_y_data(), example_yrep_draws(), example_group_data())
+#' pgroup <- facet_relabel_gg(pgroup, labels = c("GroupA" = "apples", "GroupB" = "oranges"))
 #'
 #'
 #'


### PR DESCRIPTION
This (finally) adds an example to the documentation that shows how to change the facet labels via `facet_relabel_gg()` of a grouped PPC plot, as discussed in https://github.com/stan-dev/bayesplot/issues/75.