### PR TITLE
fix ppc_loo_pit_overlay() and ppc_loo_pit_qq()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,12 @@
   the order of the parameters in the original MCMC data. This change fixes a
   case where factor-conversion failed. (#162, #165, @wwiecek)
 
+* The examples in
+  [`?ppc_loo_pit_overlay()`](http://mc-stan.org/bayesplot/reference/PPC-loo.html)
+  now work as expected. (#166, #167)
+
+
+
 
 # bayesplot 1.6.0
 


### PR DESCRIPTION
This pull request fixes #166. The problems are described in that issue, and the diagnosis of the problems and their fixes are described there too. This pull request also the following warnings raised by testthat

```
test-ppc-loo.R:32: warning: ppc_loo_pit_overlay returns ggplot object
no non-missing arguments to min; returning Inf

test-ppc-loo.R:32: warning: ppc_loo_pit_overlay returns ggplot object
no non-missing arguments to max; returning -Inf
```

I don't know have a good statistical sense of what PIT is, and I didn't have any reference images for what these plots are supposed to look in general, so I would like @jgabry to review the changes here.