### PR TITLE
Call as.array on input to prepare_mcmc_array()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 <!-- Items for next release go here* -->
 
+* MCMC plots now also accept objects with an `as.array` method as 
+  input. (#175, #184)
+
 * [`mcmc_trace()`](http://mc-stan.org/bayesplot/reference/MCMC-traces.html)
   gains an argument `iter1` which can be used to label the traceplot starting
   from the first iteration after warmup. (#14, #155, @mcol)

--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -165,14 +165,16 @@ df_with_chain2array <- function(x) {
 }
 
 
-# Check if an object is a list but not a data.frame
+# Check if an object is a list (but not a data.frame) that contains
+# all 2-D objects
 #
 # @param x object to check
 # @return TRUE or FALSE
 is_chain_list <- function(x) {
   check1 <- !is.data.frame(x) && is.list(x)
   dims <- sapply(x, function(chain) length(dim(chain)))
-  isTRUE(all(dims == 2))
+  check2 <- isTRUE(all(dims == 2)) # all elements of list should be matrices/2-D arrays
+  check1 && check2
 }
 
 validate_chain_list <- function(x) {

--- a/R/mcmc-overview.R
+++ b/R/mcmc-overview.R
@@ -18,9 +18,9 @@
 #'  corresponds to a Markov chain. All of the matrices should have the same
 #'  number of iterations (rows) and parameters (columns), and parameters should
 #'  have the same names and be in the same order.
-#'  \item \strong{matrix}: A \code{\link{matrix}} with one column per parameter.
-#'  If using matrix there should only be a single Markov chain or all chains
-#'  should already be merged (stacked).
+#'  \item \strong{matrix (2-D array)}: A \code{\link{matrix}} with one column
+#'  per parameter. If using matrix there should only be a single Markov chain or
+#'  all chains should already be merged (stacked).
 #'  \item \strong{data frame}: There are two types of \link[=data.frame]{data
 #'  frames} allowed. Either a data frame with one column per parameter (if only
 #'  a single chain or all chains have already been merged), or a data frame with

--- a/man-roxygen/args-mcmc-x.R
+++ b/man-roxygen/args-mcmc-x.R
@@ -1,3 +1,5 @@
 #' @param x A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 #'   The \link{MCMC-overview} page provides details on how to specify each these
-#'   allowed inputs.
+#'   allowed inputs. It is also possible to use an object with an
+#'   \code{as.array} method that returns the same kind of 3-D array described on
+#'   the \link{MCMC-overview} page.

--- a/man/MCMC-combos.Rd
+++ b/man/MCMC-combos.Rd
@@ -11,7 +11,9 @@ mcmc_combo(x, combo = c("dens", "trace"), widths = NULL,
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{combo}{A character vector with at least two elements. Each element of
 \code{combo} corresponds to a column in the resulting graphic and should be

--- a/man/MCMC-diagnostics.Rd
+++ b/man/MCMC-diagnostics.Rd
@@ -50,7 +50,9 @@ total sample size. See \code{\link{neff_ratio}}.}
 
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -41,7 +41,9 @@ mcmc_violin(x, pars = character(), regex_pars = character(),
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -40,7 +40,9 @@ mcmc_areas_ridges_data(x, pars = character(), regex_pars = character(),
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use

--- a/man/MCMC-overview.Rd
+++ b/man/MCMC-overview.Rd
@@ -18,9 +18,9 @@ formats:
  corresponds to a Markov chain. All of the matrices should have the same
  number of iterations (rows) and parameters (columns), and parameters should
  have the same names and be in the same order.
- \item \strong{matrix}: A \code{\link{matrix}} with one column per parameter.
- If using matrix there should only be a single Markov chain or all chains
- should already be merged (stacked).
+ \item \strong{matrix (2-D array)}: A \code{\link{matrix}} with one column
+ per parameter. If using matrix there should only be a single Markov chain or
+ all chains should already be merged (stacked).
  \item \strong{data frame}: There are two types of \link[=data.frame]{data
  frames} allowed. Either a data frame with one column per parameter (if only
  a single chain or all chains have already been merged), or a data frame with

--- a/man/MCMC-parcoord.Rd
+++ b/man/MCMC-parcoord.Rd
@@ -19,7 +19,9 @@ parcoord_style_np(div_color = "red", div_size = 0.2, div_alpha = 0.2)
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use

--- a/man/MCMC-recover.Rd
+++ b/man/MCMC-recover.Rd
@@ -21,7 +21,9 @@ mcmc_recover_hist(x, true, facet_args = list(), ..., binwidth = NULL,
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{true}{A numeric vector of "true" values of the parameters in \code{x}.
 There should be one value in \code{true} for each parameter included in

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -36,7 +36,9 @@ pairs_condition(chains = NULL, draws = NULL, nuts = NULL)
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. For
 \code{mcmc_scatter} and \code{mcmc_hex} only two parameters can be

--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -21,7 +21,9 @@ trace_style_np(div_color = "red", div_size = 0.25, div_alpha = 1)
 \arguments{
 \item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
 The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs.}
+allowed inputs. It is also possible to use an object with an
+\code{as.array} method that returns the same kind of 3-D array described on
+the \link{MCMC-overview} page.}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use

--- a/man/PPC-discrete.Rd
+++ b/man/PPC-discrete.Rd
@@ -72,9 +72,10 @@ plots for ordinal, categorical, and multinomial outcomes. See the
 \strong{Plot Descriptions} section below.
 }
 \details{
-For all of these plots \code{y} and \code{yrep} must be non-negative
-  integers, although they need not be integers in the strict sense of \R's
-  \code{\link{integer}} type.
+For all of these plots \code{y} and \code{yrep} must be
+  integers, although they need not be integers in the strict sense
+  of \R's \code{\link{integer}} type. For rootogram plots \code{y}
+  and \code{yrep} must also be non-negative.
 }
 \section{Plot Descriptions}{
 

--- a/tests/testthat/test-helpers-mcmc.R
+++ b/tests/testthat/test-helpers-mcmc.R
@@ -24,30 +24,6 @@ test_that("melt_mcmc does not convert integer parameter names to integers #162",
 })
 
 
-
-# validate_mcmc_x ----------------------------------------------------------
-test_that("validate_mcmc_x works", {
-  expect_identical(validate_mcmc_x(mat), mat)
-  expect_identical(validate_mcmc_x(mat1), mat1)
-  expect_identical(validate_mcmc_x(arr), arr)
-  expect_identical(validate_mcmc_x(arr1), arr1)
-  expect_identical(validate_mcmc_x(arr1chain), arr1chain)
-
-  # error if df_with_chain
-  expect_error(validate_mcmc_x(dframe_multiple_chains), "is_df_with_chain")
-
-  # converts regular df to matrix
-  expect_identical(validate_mcmc_x(dframe), as.matrix(dframe))
-
-  # NAs
-  mat[1, 2] <- NA
-  arr[1, 2, 3] <- NA
-  expect_error(validate_mcmc_x(mat), "NAs not allowed")
-  expect_error(validate_mcmc_x(arr), "NAs not allowed")
-})
-
-
-
 # 3-D array helpers --------------------------------------------------------
 test_that("is_mcmc_array works", {
   expect_false(is_mcmc_array(mat))
@@ -153,7 +129,6 @@ test_that("is_chain_list works", {
 })
 
 test_that("validate_chain_list works", {
-  expect_error(validate_chain_list(mat), "is_chain_list")
   expect_identical(validate_chain_list(chainlist), chainlist)
   expect_identical(validate_chain_list(chainlist1), chainlist1)
   expect_identical(validate_chain_list(chainlist1chain), chainlist1chain)
@@ -172,8 +147,6 @@ test_that("chain_list2array works", {
   expect_mcmc_array(chain_list2array(chainlist))
   expect_mcmc_array(chain_list2array(chainlist1))
   expect_mcmc_array(chain_list2array(chainlist1chain))
-
-  expect_error(chain_list2array(dframe), "is_chain_list")
 })
 
 
@@ -230,6 +203,42 @@ test_that("transformations recycled properly if not a named list", {
   expect_identical(parameter_names(x), c("t(beta[1])", "t(sigma)"))
 })
 
+
+# prepare_mcmc_array ------------------------------------------------------
+test_that("prepare_mcmc_array processes non-array input types correctly", {
+  # errors are mostly covered by tests of the many internal functions above
+
+  # data frame with no Chain column (treat as 1 chain or merged chains)
+  a1 <- prepare_mcmc_array(dframe)
+  expect_s3_class(a1, "mcmc_array")
+  expect_equal(dim(a1), c(nrow(dframe), 1, ncol(dframe)))
+  expect_equal(parameter_names(a1), colnames(dframe))
+
+  # data frame with Chain column
+  a2 <- prepare_mcmc_array(dframe_multiple_chains)
+  expect_s3_class(a2, "mcmc_array")
+  n_chain <- max(dframe_multiple_chains$chain)
+  expect_equal(dim(a2), c(nrow(dframe) / n_chain, n_chain, ncol(dframe)))
+  expect_equal(parameter_names(a2), colnames(dframe))
+
+  # list of matrices with multiple chains
+  a3 <- prepare_mcmc_array(chainlist)
+  expect_s3_class(a3, "mcmc_array")
+  expect_equal(dim(a3), c(nrow(chainlist[[1]]), length(chainlist), ncol(chainlist[[1]])))
+  expect_equal(parameter_names(a3), colnames(chainlist[[1]]))
+
+  # object with acceptable as.array method
+  suppressPackageStartupMessages(library(rstanarm))
+  fit <- stan_glm(mpg ~ wt, data = mtcars, chains = 2, iter = 500, refresh = 0)
+  a4 <- prepare_mcmc_array(fit)
+  expect_s3_class(a4, "mcmc_array")
+  expect_equal(dim(a4), c(250, 2, 3))
+  expect_equal(parameter_names(a4), c("(Intercept)", "wt", "sigma"))
+
+  # object with unacceptable as.array method
+  fit2 <- lm(mpg ~ wt, data = mtcars)
+  expect_error(prepare_mcmc_array(fit2), "Arrays should have 2 or 3 dimensions.")
+})
 
 
 # rhat and neff helpers ---------------------------------------------------

--- a/tests/testthat/test-helpers-mcmc.R
+++ b/tests/testthat/test-helpers-mcmc.R
@@ -232,6 +232,7 @@ test_that("prepare_mcmc_array processes non-array input types correctly", {
   fit <- stan_glm(mpg ~ wt, data = mtcars, chains = 2, iter = 500, refresh = 0)
   a4 <- prepare_mcmc_array(fit)
   expect_s3_class(a4, "mcmc_array")
+  expect_equal(a4, prepare_mcmc_array(as.array(fit)))
   expect_equal(dim(a4), c(250, 2, 3))
   expect_equal(parameter_names(a4), c("(Intercept)", "wt", "sigma"))
 


### PR DESCRIPTION
Closes #175.

As suggested by @bgoodri, with this PR objects with as.array methods can now be passed to the MCMC plots (not the PPC plots) without the user having to call as.array. For example, 

```r
fit <- stan_glm(mpg ~ wt, data = mtcars)

# these give the same result now
mcmc_hist(fit)
mcmc_hist(as.array(fit))
```

If the resulting array doesn't have 2 or 3 dimensions an error is thrown. 