### PR TITLE
Add ColorBrewer palettes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Suggests:
     gridExtra (>= 2.2.1),
     knitr (>= 1.16),
     loo (>= 2.0.0),
+    RColorBrewer,
     rmarkdown (>= 1.0.0),
     rstan (>= 2.17.1),
     rstanarm (>= 2.17.4),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 <!-- Items for next release go here* -->
 
 * ColorBrewer palettes are now available as color schemes via
-  [`color_scheme_set()`](https://mc-stan.org/bayesplot/reference/bayesplot-colors.html). (#177)
+  [`color_scheme_set()`](https://mc-stan.org/bayesplot/reference/bayesplot-colors.html). (#177,#190)
 
 * MCMC plots now also accept objects with an `as.array` method as 
   input (e.g., stanfit objects). (#175, #184)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 <!-- Items for next release go here* -->
 
+* ColorBrewer palettes are now available as color schemes via
+  [`color_scheme_set()`](https://mc-stan.org/bayesplot/reference/bayesplot-colors.html). (#177)
+
 * MCMC plots now also accept objects with an `as.array` method as 
   input (e.g., stanfit objects). (#175, #184)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,11 @@
 
 <!-- Items for next release go here* -->
 
-* ColorBrewer palettes are now available as color schemes via
-  [`color_scheme_set()`](https://mc-stan.org/bayesplot/reference/bayesplot-colors.html). (#177,#190)
+* [ColorBrewer](http://colorbrewer2.org) palettes are now available as color
+  schemes via
+  [`color_scheme_set()`](https://mc-stan.org/bayesplot/reference/bayesplot-colors.html).
+  For example, `color_scheme_set("brewer-Spectral")` will use the Spectral 
+  palette. (#177, #190)
 
 * MCMC plots now also accept objects with an `as.array` method as 
   input (e.g., stanfit objects). (#175, #184)

--- a/R/bayesplot-colors.R
+++ b/R/bayesplot-colors.R
@@ -1,66 +1,70 @@
 #' Set, get, or view color schemes
 #'
 #' Set, get, or view color schemes. Choose from a preset scheme or create a
-#' custom scheme.
+#' custom scheme. See the **Available color schemes** section below for a list
+#' of available scheme names. The **Custom color schemes** section describes how
+#' to specify a custom scheme.
 #'
+#' @md
 #' @name bayesplot-colors
+#' @param scheme For `color_scheme_set()`, either a string naming one of the
+#'   available color schemes or a character vector of _exactly six_ colors
+#'   specifying a custom scheme.
 #'
-#' @param scheme For \code{color_scheme_set}, either a string naming one of the
-#'   available color schemes or a character vector of \emph{exactly six} colors
-#'   specifying a custom scheme (see the \strong{Custom Color Schemes} section,
-#'   below, for more on specifying a custom scheme).
-#'
-#'   For \code{color_scheme_get}, \code{scheme} can be missing (to get the
+#'   For `color_scheme_get()`, `scheme` can be missing (to get the
 #'   current color scheme) or a string naming one of the preset schemes.
 #'
-#'   For \code{color_scheme_view}, \code{scheme} can be missing (to use the
+#'   For `color_scheme_view()`, `scheme` can be missing (to use the
 #'   current color scheme) or a character vector containing a subset of the
 #'   available scheme names.
 #'
-#'   Currently, the available preset color schemes are:
-#'   \itemize{
-#'    \item \code{"blue"}, \code{"brightblue"}
-#'    \item \code{"gray"}, \code{"darkgray"}
-#'    \item \code{"green"}
-#'    \item \code{"pink"}
-#'    \item \code{"purple"}
-#'    \item \code{"red"}
-#'    \item \code{"teal"}
-#'    \item \code{"yellow"}
-#'    \item \href{https://CRAN.R-project.org/package=viridis}{\code{"viridis"}},
-#'      \code{"viridisA"}, \code{"viridisB"}, \code{"viridisC"}
-#'    \item \code{"mix-x-y"}, replacing \code{x} and \code{y} with any two of
-#'      the scheme names listed above (e.g. "mix-teal-pink", "mix-blue-red",
-#'      etc.). The order of \code{x} and \code{y} matters, i.e., the color
-#'      schemes "mix-blue-red" and "mix-red-blue" are not identical. There is no
-#'      guarantee that every possible mixed scheme will look good with every
-#'      possible plot.
-#'   }
+#'   See the **Available color schemes** section below for a list of available
+#'   scheme names. The **Custom color schemes** section describes how to specify
+#'   a custom scheme.
 #'
-#'   If you have a suggestion for a new color scheme please let us know via the
-#'   \pkg{bayesplot} \href{https://github.com/stan-dev/bayesplot/issues}{issue
-#'   tracker}.
+#' @return `color_scheme_set()` has the side effect of setting the color scheme
+#'   used for plotting. It also returns ([invisibly][base::invisible]) a list of
+#'   the hexidecimal color values used in `scheme`.
 #'
-#' @return \code{color_scheme_set} has the side effect of setting the color
-#'   scheme used for plotting. It also returns
-#'   (\code{\link[=invisible]{invisibly}}) a list of the hexidecimal color
-#'   values used in \code{scheme}.
-#'
-#'   \code{color_scheme_get} returns a \code{list} of the hexadecimal color
-#'   values (without changing the current scheme). If the \code{scheme} argument
+#'   `color_scheme_get()` returns a list of the hexadecimal color
+#'   values (without changing the current scheme). If the `scheme` argument
 #'   is not specified the returned values correspond to the current color
-#'   scheme. If the optional argument \code{i} is specified then the returned
-#'   list only contains \code{length(i)} elements.
+#'   scheme. If the optional argument `i` is specified then the returned
+#'   list only contains `length(i)` elements.
 #'
-#'   \code{color_scheme_view} returns a ggplot object if only a single scheme is
+#'   `color_scheme_view()` returns a ggplot object if only a single scheme is
 #'   specified and a gtable object if multiple schemes names are specified.
 #'
-#' @section Custom Color Schemes: A \pkg{bayesplot} color scheme consists of six
+#' @section Available color schemes: Currently, the available preset color
+#'   schemes are:
+#'  * `"blue"`, `"brightblue"`
+#'  * `"gray"`, `"darkgray"`
+#'  * `"green"`
+#'  * `"pink"`
+#'  * `"purple"`
+#'  * `"red"`
+#'  * `"teal"`
+#'  * `"yellow"`
+#'  * [`"viridis"`](https://CRAN.R-project.org/package=viridis), `"viridisA"`,
+#'    `"viridisB"`, `"viridisC"`
+#'  * `"mix-x-y"`, replacing `x` and `y` with any two of
+#'      the scheme names listed above (e.g. "mix-teal-pink", "mix-blue-red",
+#'      etc.). The order of `x` and `y` matters, i.e., the color schemes
+#'      `"mix-blue-red"` and `"mix-red-blue"` are not identical. There is no
+#'      guarantee that every possible mixed scheme will look good with every
+#'      possible plot.
+#'  * `"brewer-x"`, replacing `x` with the name of a palette available from
+#'     [RColorBrewer::brewer.pal()] (e.g., `brewer-PuBuGn`).
+#'
+#'  If you have a suggestion for a new color scheme please let us know via the
+#'  **bayesplot** [issue tracker](https://github.com/stan-dev/bayesplot/issues).
+#'
+#' @section Custom color schemes: A **bayesplot** color scheme consists of six
 #'   colors. To specify a custom color scheme simply pass a character vector
-#'   containing either the names of six \code{\link[grDevices]{colors}} or six
+#'   containing either the names of six [colors][grDevices::colors] or six
 #'   hexidecimal color values (or a mix of names and hex values). The colors
 #'   should be in order from lightest to darkest. See the end of the
-#'   \strong{Examples} section for a demonstration.
+#'   **Examples** section for a demonstration.
 #'
 #' @template seealso-theme
 #'
@@ -128,10 +132,11 @@ color_scheme_set <- function(scheme = "blue") {
 }
 
 #' @rdname bayesplot-colors
+#' @md
 #' @export
-#' @param i For \code{color_scheme_get}, a subset of the integers from \code{1}
-#'   (lightest) to \code{6} (darkest) indicating which of the colors in the
-#'   scheme to return. If \code{i} is not specified then all six colors in the
+#' @param i For `color_scheme_get()`, a subset of the integers from `1`
+#'   (lightest) to `6` (darkest) indicating which of the colors in the
+#'   scheme to return. If `i` is not specified then all six colors in the
 #'   scheme are included.
 #'
 color_scheme_get <- function(scheme, i) {
@@ -229,11 +234,19 @@ scheme_from_string <- function(scheme) {
   if (identical(substr(scheme, 1, 4), "mix-")) {
     to_mix <- unlist(strsplit(scheme, split = "-"))[2:3]
     x <- setNames(mixed_scheme(to_mix[1], to_mix[2]), scheme_level_names())
-    structure(x, mixed = TRUE, scheme_name = scheme)
+    return(structure(x, mixed = TRUE, scheme_name = scheme))
+  } else if (identical(substr(scheme, 1, 7), "brewer-")) {
+    if (!requireNamespace("RColorBrewer", quietly = TRUE)) {
+      stop("Please install the 'RColorBrewer' package to use a ColorBrewer scheme.",
+           call.=FALSE)
+    }
+    clrs <- RColorBrewer::brewer.pal(n = 6, name = gsub("brewer-", "", scheme))
+    x <- setNames(as.list(clrs), scheme_level_names())
+    return(structure(x, mixed = FALSE, scheme_name = scheme))
   } else {
     scheme <- match.arg(scheme, choices = names(master_color_list))
     x <- prepare_colors(scheme)
-    structure(x, mixed = FALSE, scheme_name = scheme)
+    return(structure(x, mixed = FALSE, scheme_name = scheme))
   }
 }
 
@@ -244,13 +257,14 @@ is_mixed_scheme <- function(x) {
   isTRUE(attr(x, "mixed"))
 }
 
-# Access a subset of the scheme colors
-#
-# @param level A character vector of level names (see scheme_level_names()). The
-#   abbreviations "l", "lh", "m", "mh", "d", and "dh" can also be used instead
-#   of the full names.
-# @return A character vector of color values.
-#
+#' Access a subset of the scheme colors
+#'
+#' @noRd
+#' @param level A character vector of level names (see `scheme_level_names()`).
+#'   The abbreviations "l", "lh", "m", "mh", "d", and "dh" can also be used
+#'   instead of the full names.
+#' @return A character vector of color values.
+#'
 get_color <- function(levels) {
   sel <- which(!levels %in% scheme_level_names())
   if (length(sel))

--- a/R/bayesplot-colors.R
+++ b/R/bayesplot-colors.R
@@ -106,10 +106,11 @@
 #' ppc_stat(y, yrep, stat = "sd") + legend_none()
 #' mcmc_areas(x, regex_pars = "beta")
 #'
-#' ###########################
-#' ### ColorBrewer schemes ###
-#' ###########################
+#' ##########################
+#' ### ColorBrewer scheme ###
+#' ##########################
 #' color_scheme_set("brewer-Spectral")
+#' color_scheme_view()
 #' mcmc_trace(x, pars = "sigma")
 #'
 #' ###########################
@@ -119,6 +120,7 @@
 #'                    "#ffad33", "#e68a00",
 #'                    "#995c00", "#663d00")
 #' color_scheme_set(orange_scheme)
+#' color_scheme_view()
 #' mcmc_areas(x, regex_pars = "alpha")
 #' mcmc_dens_overlay(x)
 #' ppc_stat(y, yrep, stat = "var") + legend_none()
@@ -171,20 +173,6 @@ color_scheme_get <- function(scheme, i) {
   scheme[i]
 }
 
-#' @export
-print.bayesplot_scheme <- function(x, ...) {
-  tab <- data.frame(unlist(x, use.names = FALSE),
-                    stringsAsFactors = FALSE)
-  colnames(tab) <- attr(x, "scheme_name") %||% "hex_color"
-  print(tab, ...)
-}
-#' @export
-plot.bayesplot_scheme <- function(x, ...) {
-  scheme <- attr(x, "scheme_name") %||% stop("Scheme name not found.")
-  plot_scheme(scheme)
-}
-
-
 #' @rdname bayesplot-colors
 #' @export
 color_scheme_view <- function(scheme = NULL) {
@@ -198,6 +186,17 @@ color_scheme_view <- function(scheme = NULL) {
   )
 }
 
+#' @export
+print.bayesplot_scheme <- function(x, ...) {
+  tab <- data.frame(unlist(x, use.names = FALSE), stringsAsFactors = FALSE)
+  colnames(tab) <- attr(x, "scheme_name") %||% "hex_color"
+  print(tab, ...)
+}
+#' @export
+plot.bayesplot_scheme <- function(x, ...) {
+  scheme <- attr(x, "scheme_name") %||% stop("Scheme name not found.")
+  plot_scheme(scheme)
+}
 
 
 # internal -----------------------------------------------------------------
@@ -207,25 +206,17 @@ color_scheme_view <- function(scheme = NULL) {
 plot_scheme <- function(scheme = NULL) {
   if (is.null(scheme)) {
     x <- color_scheme_get()
-    x_name <- ""
   } else {
     x <- color_scheme_get(scheme)
-    x_name <- factor(scheme)
   }
 
   color_data <- data.frame(
-    name = x_name,
+    name = factor(attr(x, "scheme_name")),
     group = factor(names(x), levels = rev(names(x))),
     value = rep(1, length(x))
   )
-  ggplot(
-    color_data,
-    aes_(
-      x = ~ name,
-      y = ~ value,
-      fill = ~ group
-    )
-  ) +
+
+  ggplot(color_data, aes_(x = ~ name, y = ~ value, fill = ~ group)) +
     geom_bar(
       width = .5,
       stat = "identity",

--- a/R/bayesplot-colors.R
+++ b/R/bayesplot-colors.R
@@ -98,13 +98,22 @@
 #' y <- example_y_data()
 #' yrep <- example_yrep_draws()
 #' ppc_stat(y, yrep, stat = "mean") + legend_none()
-#' \donttest{
+#'
+#' ############################
+#' ### Mixing color schemes ###
+#' ############################
 #' color_scheme_set("mix-teal-pink")
 #' ppc_stat(y, yrep, stat = "sd") + legend_none()
 #' mcmc_areas(x, regex_pars = "beta")
-#' }
+#'
 #' ###########################
-#' ### custom color scheme ###
+#' ### ColorBrewer schemes ###
+#' ###########################
+#' color_scheme_set("brewer-Spectral")
+#' mcmc_trace(x, pars = "sigma")
+#'
+#' ###########################
+#' ### Custom color scheme ###
 #' ###########################
 #' orange_scheme <- c("#ffebcc", "#ffcc80",
 #'                    "#ffad33", "#e68a00",

--- a/R/bayesplot-colors.R
+++ b/R/bayesplot-colors.R
@@ -172,7 +172,7 @@ print.bayesplot_scheme <- function(x, ...) {
 #' @export
 plot.bayesplot_scheme <- function(x, ...) {
   scheme <- attr(x, "scheme_name") %||% stop("Scheme name not found.")
-  .view_scheme(scheme)
+  plot_scheme(scheme)
 }
 
 
@@ -180,10 +180,10 @@ plot.bayesplot_scheme <- function(x, ...) {
 #' @export
 color_scheme_view <- function(scheme) {
   if (missing(scheme) || length(scheme) == 1)
-    return(.view_scheme(scheme))
+    return(plot_scheme(scheme))
 
   bayesplot_grid(
-    plots = lapply(scheme, .view_scheme),
+    plots = lapply(scheme, plot_scheme),
     grid_args = list(ncol = length(scheme))
   )
 }
@@ -194,7 +194,7 @@ color_scheme_view <- function(scheme) {
 
 # plot color scheme
 # @param scheme A string (length 1) naming a scheme
-.view_scheme <- function(scheme) {
+plot_scheme <- function(scheme) {
   x <- if (missing(scheme))
     color_scheme_get() else color_scheme_get(scheme)
 

--- a/R/bayesplot-colors.R
+++ b/R/bayesplot-colors.R
@@ -145,13 +145,13 @@ color_scheme_set <- function(scheme = "blue") {
 #' @rdname bayesplot-colors
 #' @md
 #' @export
-#' @param i For `color_scheme_get()`, a subset of the integers from `1`
+#' @param i For `color_scheme_get()`, an optional subset of the integers from `1`
 #'   (lightest) to `6` (darkest) indicating which of the colors in the
 #'   scheme to return. If `i` is not specified then all six colors in the
 #'   scheme are included.
 #'
-color_scheme_get <- function(scheme, i) {
-  if (!missing(scheme)) {
+color_scheme_get <- function(scheme = NULL, i = NULL) {
+  if (!is.null(scheme)) {
     scheme <- scheme_from_string(scheme)
   } else {
     x <- .bayesplot_aesthetics$scheme
@@ -160,7 +160,8 @@ color_scheme_get <- function(scheme, i) {
     attr(scheme, "scheme_name") <- attr(x, "scheme_name")
   }
   class(scheme) <- c("bayesplot_scheme", "list")
-  if (missing(i)) {
+
+  if (is.null(i)) {
     return(scheme)
   } else if (is.character(i)) {
     return(get_color(i))
@@ -179,7 +180,6 @@ color_scheme_view <- function(scheme = NULL) {
   if (is.null(scheme) || length(scheme) == 1){
     return(plot_scheme(scheme))
   }
-
   bayesplot_grid(
     plots = lapply(scheme, plot_scheme),
     grid_args = list(ncol = length(scheme))
@@ -192,6 +192,7 @@ print.bayesplot_scheme <- function(x, ...) {
   colnames(tab) <- attr(x, "scheme_name") %||% "hex_color"
   print(tab, ...)
 }
+
 #' @export
 plot.bayesplot_scheme <- function(x, ...) {
   scheme <- attr(x, "scheme_name") %||% stop("Scheme name not found.")
@@ -339,8 +340,9 @@ prepare_custom_colors <- function(scheme) {
   not_found <- character(0)
   for (j in seq_along(scheme)) {
     clr <- scheme[j]
-    if (!is_hex_color(clr)  && !clr %in% grDevices::colors())
+    if (!is_hex_color(clr)  && !clr %in% grDevices::colors()) {
       not_found <- c(not_found, clr)
+    }
   }
   if (length(not_found)) {
     stop(

--- a/R/bayesplot-ggplot-themes.R
+++ b/R/bayesplot-ggplot-themes.R
@@ -13,8 +13,9 @@
 #'   \code{"serif"}, respectively.
 #' @return A ggplot \link[ggplot2]{theme} object.
 #'
-#' @template seealso-helpers
+#' @seealso \code{\link{bayesplot_theme_set}} to change the ggplot theme.
 #' @template seealso-colors
+#' @template seealso-helpers
 #'
 #' @examples
 #' class(theme_default())

--- a/man-roxygen/seealso-theme.R
+++ b/man-roxygen/seealso-theme.R
@@ -1,2 +1,2 @@
 #' @seealso \code{\link{theme_default}} for the default ggplot theme used by
-#'   \pkg{bayesplot}.
+#'   \pkg{bayesplot} and \code{\link{bayesplot_theme_set}} to change it.

--- a/man/bayesplot-colors.Rd
+++ b/man/bayesplot-colors.Rd
@@ -11,7 +11,7 @@ color_scheme_set(scheme = "blue")
 
 color_scheme_get(scheme, i)
 
-color_scheme_view(scheme)
+color_scheme_view(scheme = NULL)
 }
 \arguments{
 \item{scheme}{For \code{color_scheme_set()}, either a string naming one of the

--- a/man/bayesplot-colors.Rd
+++ b/man/bayesplot-colors.Rd
@@ -14,73 +14,81 @@ color_scheme_get(scheme, i)
 color_scheme_view(scheme)
 }
 \arguments{
-\item{scheme}{For \code{color_scheme_set}, either a string naming one of the
-  available color schemes or a character vector of \emph{exactly six} colors
-  specifying a custom scheme (see the \strong{Custom Color Schemes} section,
-  below, for more on specifying a custom scheme).
+\item{scheme}{For \code{color_scheme_set()}, either a string naming one of the
+available color schemes or a character vector of \emph{exactly six} colors
+specifying a custom scheme.
 
-  For \code{color_scheme_get}, \code{scheme} can be missing (to get the
-  current color scheme) or a string naming one of the preset schemes.
+For \code{color_scheme_get()}, \code{scheme} can be missing (to get the
+current color scheme) or a string naming one of the preset schemes.
 
-  For \code{color_scheme_view}, \code{scheme} can be missing (to use the
-  current color scheme) or a character vector containing a subset of the
-  available scheme names.
+For \code{color_scheme_view()}, \code{scheme} can be missing (to use the
+current color scheme) or a character vector containing a subset of the
+available scheme names.
 
-  Currently, the available preset color schemes are:
-  \itemize{
-   \item \code{"blue"}, \code{"brightblue"}
-   \item \code{"gray"}, \code{"darkgray"}
-   \item \code{"green"}
-   \item \code{"pink"}
-   \item \code{"purple"}
-   \item \code{"red"}
-   \item \code{"teal"}
-   \item \code{"yellow"}
-   \item \href{https://CRAN.R-project.org/package=viridis}{\code{"viridis"}},
-     \code{"viridisA"}, \code{"viridisB"}, \code{"viridisC"}
-   \item \code{"mix-x-y"}, replacing \code{x} and \code{y} with any two of
-     the scheme names listed above (e.g. "mix-teal-pink", "mix-blue-red",
-     etc.). The order of \code{x} and \code{y} matters, i.e., the color
-     schemes "mix-blue-red" and "mix-red-blue" are not identical. There is no
-     guarantee that every possible mixed scheme will look good with every
-     possible plot.
-  }
+See the \strong{Available color schemes} section below for a list of available
+scheme names. The \strong{Custom color schemes} section describes how to specify
+a custom scheme.}
 
-  If you have a suggestion for a new color scheme please let us know via the
-  \pkg{bayesplot} \href{https://github.com/stan-dev/bayesplot/issues}{issue
-  tracker}.}
-
-\item{i}{For \code{color_scheme_get}, a subset of the integers from \code{1}
+\item{i}{For \code{color_scheme_get()}, a subset of the integers from \code{1}
 (lightest) to \code{6} (darkest) indicating which of the colors in the
 scheme to return. If \code{i} is not specified then all six colors in the
 scheme are included.}
 }
 \value{
-\code{color_scheme_set} has the side effect of setting the color
-  scheme used for plotting. It also returns
-  (\code{\link[=invisible]{invisibly}}) a list of the hexidecimal color
-  values used in \code{scheme}.
+\code{color_scheme_set()} has the side effect of setting the color scheme
+used for plotting. It also returns (\link[base:invisible]{invisibly}) a list of
+the hexidecimal color values used in \code{scheme}.
 
-  \code{color_scheme_get} returns a \code{list} of the hexadecimal color
-  values (without changing the current scheme). If the \code{scheme} argument
-  is not specified the returned values correspond to the current color
-  scheme. If the optional argument \code{i} is specified then the returned
-  list only contains \code{length(i)} elements.
+\code{color_scheme_get()} returns a list of the hexadecimal color
+values (without changing the current scheme). If the \code{scheme} argument
+is not specified the returned values correspond to the current color
+scheme. If the optional argument \code{i} is specified then the returned
+list only contains \code{length(i)} elements.
 
-  \code{color_scheme_view} returns a ggplot object if only a single scheme is
-  specified and a gtable object if multiple schemes names are specified.
+\code{color_scheme_view()} returns a ggplot object if only a single scheme is
+specified and a gtable object if multiple schemes names are specified.
 }
 \description{
 Set, get, or view color schemes. Choose from a preset scheme or create a
-custom scheme.
+custom scheme. See the \strong{Available color schemes} section below for a list
+of available scheme names. The \strong{Custom color schemes} section describes how
+to specify a custom scheme.
 }
-\section{Custom Color Schemes}{
- A \pkg{bayesplot} color scheme consists of six
-  colors. To specify a custom color scheme simply pass a character vector
-  containing either the names of six \code{\link[grDevices]{colors}} or six
-  hexidecimal color values (or a mix of names and hex values). The colors
-  should be in order from lightest to darkest. See the end of the
-  \strong{Examples} section for a demonstration.
+\section{Available color schemes}{
+ Currently, the available preset color
+schemes are:
+\itemize{
+\item \code{"blue"}, \code{"brightblue"}
+\item \code{"gray"}, \code{"darkgray"}
+\item \code{"green"}
+\item \code{"pink"}
+\item \code{"purple"}
+\item \code{"red"}
+\item \code{"teal"}
+\item \code{"yellow"}
+\item \href{https://CRAN.R-project.org/package=viridis}{"viridis"}, \code{"viridisA"},
+\code{"viridisB"}, \code{"viridisC"}
+\item \code{"mix-x-y"}, replacing \code{x} and \code{y} with any two of
+the scheme names listed above (e.g. "mix-teal-pink", "mix-blue-red",
+etc.). The order of \code{x} and \code{y} matters, i.e., the color schemes
+\code{"mix-blue-red"} and \code{"mix-red-blue"} are not identical. There is no
+guarantee that every possible mixed scheme will look good with every
+possible plot.
+\item \code{"brewer-x"}, replacing \code{x} with the name of a palette available from
+\code{\link[RColorBrewer:brewer.pal]{RColorBrewer::brewer.pal()}} (e.g., \code{brewer-PuBuGn}).
+}
+
+If you have a suggestion for a new color scheme please let us know via the
+\strong{bayesplot} \href{https://github.com/stan-dev/bayesplot/issues}{issue tracker}.
+}
+
+\section{Custom color schemes}{
+ A \strong{bayesplot} color scheme consists of six
+colors. To specify a custom color scheme simply pass a character vector
+containing either the names of six \link[grDevices:colors]{colors} or six
+hexidecimal color values (or a mix of names and hex values). The colors
+should be in order from lightest to darkest. See the end of the
+\strong{Examples} section for a demonstration.
 }
 
 \examples{

--- a/man/bayesplot-colors.Rd
+++ b/man/bayesplot-colors.Rd
@@ -151,5 +151,5 @@ ppc_stat(y, yrep, stat = "var") + legend_none()
 }
 \seealso{
 \code{\link{theme_default}} for the default ggplot theme used by
-  \pkg{bayesplot}.
+  \pkg{bayesplot} and \code{\link{bayesplot_theme_set}} to change it.
 }

--- a/man/bayesplot-colors.Rd
+++ b/man/bayesplot-colors.Rd
@@ -121,13 +121,22 @@ color_scheme_view()
 y <- example_y_data()
 yrep <- example_yrep_draws()
 ppc_stat(y, yrep, stat = "mean") + legend_none()
-\donttest{
+
+############################
+### Mixing color schemes ###
+############################
 color_scheme_set("mix-teal-pink")
 ppc_stat(y, yrep, stat = "sd") + legend_none()
 mcmc_areas(x, regex_pars = "beta")
-}
+
 ###########################
-### custom color scheme ###
+### ColorBrewer schemes ###
+###########################
+color_scheme_set("brewer-Spectral")
+mcmc_trace(x, pars = "sigma")
+
+###########################
+### Custom color scheme ###
 ###########################
 orange_scheme <- c("#ffebcc", "#ffcc80",
                    "#ffad33", "#e68a00",

--- a/man/bayesplot-colors.Rd
+++ b/man/bayesplot-colors.Rd
@@ -9,7 +9,7 @@
 \usage{
 color_scheme_set(scheme = "blue")
 
-color_scheme_get(scheme, i)
+color_scheme_get(scheme = NULL, i = NULL)
 
 color_scheme_view(scheme = NULL)
 }
@@ -29,7 +29,7 @@ See the \strong{Available color schemes} section below for a list of available
 scheme names. The \strong{Custom color schemes} section describes how to specify
 a custom scheme.}
 
-\item{i}{For \code{color_scheme_get()}, a subset of the integers from \code{1}
+\item{i}{For \code{color_scheme_get()}, an optional subset of the integers from \code{1}
 (lightest) to \code{6} (darkest) indicating which of the colors in the
 scheme to return. If \code{i} is not specified then all six colors in the
 scheme are included.}
@@ -129,10 +129,11 @@ color_scheme_set("mix-teal-pink")
 ppc_stat(y, yrep, stat = "sd") + legend_none()
 mcmc_areas(x, regex_pars = "beta")
 
-###########################
-### ColorBrewer schemes ###
-###########################
+##########################
+### ColorBrewer scheme ###
+##########################
 color_scheme_set("brewer-Spectral")
+color_scheme_view()
 mcmc_trace(x, pars = "sigma")
 
 ###########################
@@ -142,6 +143,7 @@ orange_scheme <- c("#ffebcc", "#ffcc80",
                    "#ffad33", "#e68a00",
                    "#995c00", "#663d00")
 color_scheme_set(orange_scheme)
+color_scheme_view()
 mcmc_areas(x, regex_pars = "alpha")
 mcmc_dens_overlay(x)
 ppc_stat(y, yrep, stat = "var") + legend_none()

--- a/man/bayesplot-package.Rd
+++ b/man/bayesplot-package.Rd
@@ -103,7 +103,7 @@ Gabry, J. , Simpson, D. , Vehtari, A. , Betancourt, M. and
 }
 \seealso{
 \code{\link{theme_default}} for the default ggplot theme used by
-  \pkg{bayesplot}.
+  \pkg{bayesplot} and \code{\link{bayesplot_theme_set}} to change it.
 
 \code{\link{bayesplot-colors}} to set or view the color scheme used
   for plotting.

--- a/man/theme_default.Rd
+++ b/man/theme_default.Rd
@@ -41,10 +41,12 @@ mcmc_areas(x, regex_pars = "beta")
 
 }
 \seealso{
-\link{bayesplot-helpers} for a variety of convenience functions,
-  many of which provide shortcuts for tweaking theme elements after creating
-  a plot.
+\code{\link{bayesplot_theme_set}} to change the ggplot theme.
 
 \code{\link{bayesplot-colors}} to set or view the color scheme used
   for plotting.
+
+\link{bayesplot-helpers} for a variety of convenience functions,
+  many of which provide shortcuts for tweaking theme elements after creating
+  a plot.
 }

--- a/tests/figs/aesthetics/color-scheme-view-brewer-palette.svg
+++ b/tests/figs/aesthetics/color-scheme-view-brewer-palette.svg
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5'>
+    <rect x='0.00' y='17.29' width='720.00' height='541.00' />
+  </clipPath>
+</defs>
+<rect x='210.00' y='451.73' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #D53E4F;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='369.76' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FC8D59;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='287.79' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #FEE08B;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='205.82' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #E6F598;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='123.85' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #99D594;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='41.88' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #3288BD;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='314.66' y='563.55' style='font-size: 12.00px; font-weight: bold; font-family: Liberation Sans;' textLength='90.69px' lengthAdjust='spacingAndGlyphs'>brewer-Spectral</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='211.73px' lengthAdjust='spacingAndGlyphs'>color_scheme_view (brewer palette)</text></g>
+</svg>

--- a/tests/figs/aesthetics/color-scheme-view-default.svg
+++ b/tests/figs/aesthetics/color-scheme-view-default.svg
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5'>
+    <rect x='0.00' y='17.29' width='720.00' height='541.00' />
+  </clipPath>
+</defs>
+<rect x='210.00' y='451.73' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #D1E1EC;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='369.76' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B3CDE0;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='287.79' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='205.82' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #005B96;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='123.85' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #03396C;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='41.88' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #011F4B;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='347.67' y='563.55' style='font-size: 12.00px; font-weight: bold; font-family: Liberation Sans;' textLength='24.66px' lengthAdjust='spacingAndGlyphs'>blue</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='167.78px' lengthAdjust='spacingAndGlyphs'>color_scheme_view (default)</text></g>
+</svg>

--- a/tests/figs/aesthetics/color-scheme-view-mixed-scheme.svg
+++ b/tests/figs/aesthetics/color-scheme-view-mixed-scheme.svg
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5'>
+    <rect x='0.00' y='17.29' width='720.00' height='541.00' />
+  </clipPath>
+</defs>
+<rect x='210.00' y='451.73' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #DCBCBC;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='369.76' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B3CDE0;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='287.79' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='205.82' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A25050;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='123.85' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8F2727;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='41.88' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #011F4B;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='324.00' y='563.55' style='font-size: 12.00px; font-weight: bold; font-family: Liberation Sans;' textLength='72.00px' lengthAdjust='spacingAndGlyphs'>mix-red-blue</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='213.20px' lengthAdjust='spacingAndGlyphs'>color_scheme_view (mixed scheme)</text></g>
+</svg>

--- a/tests/figs/aesthetics/color-scheme-view-scheme-specified.svg
+++ b/tests/figs/aesthetics/color-scheme-view-scheme-specified.svg
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5'>
+    <rect x='0.00' y='17.29' width='720.00' height='541.00' />
+  </clipPath>
+</defs>
+<rect x='210.00' y='451.73' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #DCBCBC;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='369.76' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #C79999;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='287.79' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #B97C7C;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='205.82' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #A25050;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='123.85' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #8F2727;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<rect x='210.00' y='41.88' width='300.00' height='81.97' style='stroke-width: 0.21; stroke: #FFFFFF; stroke-linecap: square; stroke-linejoin: miter; fill: #7C0000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTU4LjI5fDE3LjI5)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='350.66' y='563.55' style='font-size: 12.00px; font-weight: bold; font-family: Liberation Sans;' textLength='18.67px' lengthAdjust='spacingAndGlyphs'>red</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='0.00' y='14.56' style='font-size: 13.20px; font-family: Liberation Sans;' textLength='230.06px' lengthAdjust='spacingAndGlyphs'>color_scheme_view (scheme specified)</text></g>
+</svg>

--- a/tests/testthat/test-aesthetics.R
+++ b/tests/testthat/test-aesthetics.R
@@ -200,3 +200,26 @@ test_that("ggplot2::theme_set overrides bayesplot theme", {
 
 bayesplot_theme_set(bayesplot::theme_default())
 color_scheme_set()
+
+
+
+# Visual tests ------------------------------------------------------------
+
+test_that("color_scheme_view renders correctly", {
+  testthat::skip_on_cran()
+
+  color_scheme_set()
+  p_default <- color_scheme_view()
+  vdiffr::expect_doppelganger("color_scheme_view (default)", p_default)
+
+  p_red <- color_scheme_view("red")
+  vdiffr::expect_doppelganger("color_scheme_view (scheme specified)", p_red)
+
+  p_mix <- color_scheme_view("mix-red-blue")
+  vdiffr::expect_doppelganger("color_scheme_view (mixed scheme)", p_mix)
+
+  p_brewer <- color_scheme_view("brewer-Spectral")
+  vdiffr::expect_doppelganger("color_scheme_view (brewer palette)", p_brewer)
+
+  color_scheme_set()
+})

--- a/tests/testthat/test-aesthetics.R
+++ b/tests/testthat/test-aesthetics.R
@@ -68,6 +68,15 @@ test_that("setting mixed scheme works", {
                "should be one of")
 })
 
+test_that("setting brewer scheme works", {
+  skip_if_not_installed("RColorBrewer")
+  color_scheme_set("brewer-Blues")
+  expect_equivalent(unlist(color_scheme_get()), RColorBrewer::brewer.pal(6, "Blues"))
+  color_scheme_set("brewer-Spectral")
+  expect_equivalent(unlist(color_scheme_get()), RColorBrewer::brewer.pal(6, "Spectral"))
+  expect_error(color_scheme_set("brewer-FAKE"), "FAKE is not a valid palette")
+})
+
 orange_scheme_bad <-
   orange_scheme_ok <-
   c("not_a_color1",

--- a/tests/testthat/test-aesthetics.R
+++ b/tests/testthat/test-aesthetics.R
@@ -3,14 +3,22 @@ context("Aesthetics")
 
 
 # color scheme stuff ------------------------------------------------------
+
+prepare_colors_for_test <- function(scheme) {
+  setNames(
+    bayesplot:::master_color_list[[scheme]],
+    bayesplot:::scheme_level_names()
+  )
+}
+
 test_that("getting and setting the color scheme works", {
   color_scheme_set("red")
-  expect_equivalent(color_scheme_get(), prepare_colors("red"))
-  expect_named(prepare_colors("blue"), scheme_level_names())
+  expect_equivalent(color_scheme_get(), prepare_colors_for_test("red"))
+  expect_named(prepare_colors_for_test("blue"), scheme_level_names())
   expect_named(color_scheme_get(), scheme_level_names())
   for (clr in names(master_color_list)) {
     color_scheme_set(clr)
-    expect_equivalent(color_scheme_get(), prepare_colors(clr),
+    expect_equivalent(color_scheme_get(), prepare_colors_for_test(clr),
                       info = clr)
     expect_named(color_scheme_get(), scheme_level_names())
   }
@@ -20,7 +28,7 @@ test_that("getting and setting the color scheme works", {
   expect_gg(plot(color_scheme_get("mix-blue-green")))
 
   color_scheme_set("blue")
-  expect_equivalent(color_scheme_get("teal"), prepare_colors("teal"))
+  expect_equivalent(color_scheme_get("teal"), prepare_colors_for_test("teal"))
 })
 
 test_that("color_scheme_get with i argument works", {
@@ -99,7 +107,7 @@ test_that("get_color returns correct color values", {
   scheme <- color_scheme_set("green")
   levs <- scheme_level_names()
 
-  ans <- unlist(prepare_colors("green")[levs], use.names = FALSE)
+  ans <- unlist(prepare_colors_for_test("green")[levs], use.names = FALSE)
   expect_identical(get_color(levs), ans)
   for (lev in levs)
     expect_identical(get_color(lev), scheme[[lev]], info = lev)


### PR DESCRIPTION
Closes #177 

This PR allows ColorBrewer palettes to be used with `bayesplot::color_scheme_set()`. 

Basically,  if a user specifies `color_scheme_set("brewer-X")`, where `X` is the name of a ColorBrewer palette recognized by **RColorBrewer**, then **bayesplot** will use  `RColorBrewer::brewer.pal(n = 6, name="X")` to get the colors. 

I also cleaned up and rearranged some internals in the `bayesplot-colors.R` file and changed the roxygen to use markdown, so it may seem like more changed than actually did. The only change that changes any behavior is in these lines in the internal `scheme_from_string()` function: 

https://github.com/stan-dev/bayesplot/blob/ac6f8ae78a9018f50b3353783c91f77f659a06e6/R/bayesplot-colors.R#L251-L258

#### Example Usage

```r
color_scheme_set("brewer-Spectral")
mcmc_trace(example_mcmc_draws(), pars = "sigma")
```
![brewer-example](https://user-images.githubusercontent.com/7796803/57736940-d51acd00-7677-11e9-8b06-3c7e6b718397.png)
