### PR TITLE
Rank hotfix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,14 +7,14 @@
 <!-- Items for next release go here* -->
 
 * Two new plots have been added for inspecting the distribution of ranks.
-  Rank-normalized histograms were introduced by the Stan team's [new paper on 
+  Rank histograms were introduced by the Stan team's [new paper on 
   MCMC diagnostics](https://arxiv.org/abs/1903.08008). (#178, #179)
 
   `mcmc_rank_hist()`: A traditional traceplot (`mcmc_trace()`) visualizes how
-  sampled values the MCMC chains mix over the course of sampling. A
-  rank-normalized histogram (`mcmc_rank_hist()`) visualizes how the *ranks* of
-  values from the chains mix together. An ideal plot would show the ranks mixing
-  or overlapping in a uniform distribution. 
+  sampled values the MCMC chains mix over the course of sampling. A rank
+  histogram (`mcmc_rank_hist()`) visualizes how the *ranks* of values from the
+  chains mix together. An ideal plot would show the ranks mixing or overlapping
+  in a uniform distribution.
   
   `mcmc_rank_overlay()`: Instead of drawing each chain's histogram in a separate
   panel, this plot draws the top edge of the chains' histograms in a single

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -165,7 +165,7 @@ mcmc_intervals <- function(x,
 
   data <- mcmc_intervals_data(x, pars, regex_pars, transformations,
                               prob = prob, prob_outer = prob_outer,
-                              point_est = point_est, rhat  = rhat)
+                              point_est = point_est, rhat = rhat)
 
   color_by_rhat <- rlang::has_name(data, "rhat_rating")
   no_point_est <- all(data$point_est == "none")

--- a/R/mcmc-traces.R
+++ b/R/mcmc-traces.R
@@ -54,7 +54,7 @@
 #'   }
 #'   \item{`mcmc_rank_hist()`}{
 #'    Whereas traditional trace plots visualize how the chains mix over the
-#'    course of sampling, rank-normalized histograms visualize how the values
+#'    course of sampling, rank histograms visualize how the values
 #'    from the chains mix together in terms of ranking. An ideal plot would
 #'    show the rankings mixing or overlapping in a uniform distribution.
 #'    See Vehtari et al. (2019) for details.
@@ -469,7 +469,9 @@ mcmc_trace_data <- function(x,
   first_cols <- syms(c("parameter", "value", "value_rank"))
   data <- data %>%
     group_by(.data$parameter) %>%
-    mutate(value_rank = dplyr::row_number(.data$value)) %>%
+    mutate(
+      value_rank = rank(.data$value, ties.method = "average")
+    ) %>%
     ungroup() %>%
     select(!!! first_cols, dplyr::everything())
 

--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -150,7 +150,7 @@ chains but one (specified by the \code{highlight} argument) is reduced.
 }
 \item{\code{mcmc_rank_hist()}}{
 Whereas traditional trace plots visualize how the chains mix over the
-course of sampling, rank-normalized histograms visualize how the values
+course of sampling, rank histograms visualize how the values
 from the chains mix together in terms of ranking. An ideal plot would
 show the rankings mixing or overlapping in a uniform distribution.
 See Vehtari et al. (2019) for details.

--- a/tests/testthat/test-mcmc-intervals.R
+++ b/tests/testthat/test-mcmc-intervals.R
@@ -85,9 +85,10 @@ test_that("mcmc_intervals/areas with rhat", {
   expect_error(expect_warning(mcmc_intervals(arr, rhat = rbad)))
 
   expect_gg(g <- mcmc_intervals(arr, rhat = r))
+
   if (utils::packageVersion("ggplot2") >= "3.0.0") {
     rhat_map <- g$layers[[3]][["mapping"]]
-    expect_identical(as.character(rhat_map[["colour"]]), c("~", "rhat_rating"))
+    expect_identical(rlang::as_name(rhat_map[["colour"]]), "rhat_rating")
   }
 
   # areas with rhat.
@@ -98,18 +99,18 @@ test_that("mcmc_intervals/areas with rhat", {
   expect_gg(g2 <- mcmc_areas(arr, rhat = r))
   if (utils::packageVersion("ggplot2") >= "3.0.0") {
     rhat_map2 <- g2$layers[[2]][["mapping"]]
-    expect_identical(as.character(rhat_map2$fill), c("~", "rhat_rating"))
-    expect_identical(as.character(rhat_map2$colour), c("~", "rhat_rating"))
+    expect_identical(rlang::as_name(rhat_map2$fill), "rhat_rating")
+    expect_identical(rlang::as_name(rhat_map2$colour), "rhat_rating")
+
     # layer 3 is point estimate. manually colored. [skip]
 
     # layer 4 is outer interval.
     rhat_map4 <- g2$layers[[4]][["mapping"]]
-    expect_identical(as.character(rhat_map4$colour), c("~", "rhat_rating"))
+    expect_identical(rlang::as_name(rhat_map4$colour), "rhat_rating")
 
     # layer 5 is bottom line.
-
     rhat_map5 <- g2$layers[[5]][["mapping"]]
-    expect_identical(as.character(rhat_map5$colour), c("~", "rhat_rating"))
+    expect_identical(rlang::as_name(rhat_map5$colour), "rhat_rating")
   }
 })
 


### PR DESCRIPTION
The rank-normalization paper says:

> Rank normalization proceeds as follows. First, replace each value θ^(nm) by its rank r^(nm) within the pooled draws from all chains. Average rank for ties are used to conserve the number of unique values of discrete quantities.

I was breaking ties by using `dplyr::row_number()` which works like `rank(.., ties.method = "first")`. This update changes the method to use averages.

It also fixes a warning from the unit tests.