### PR TITLE
Avoid warning when using tibbles (fixes #160)

### DIFF
--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -197,6 +197,7 @@ is_df_with_chain <- function(x) {
 
 validate_df_with_chain <- function(x) {
   stopifnot(is_df_with_chain(x))
+  x <- as.data.frame(x)
   if (!is.null(x$chain)) {
     if (is.null(x$Chain)) {
       x$Chain <- x$chain

--- a/tests/testthat/test-helpers-mcmc.R
+++ b/tests/testthat/test-helpers-mcmc.R
@@ -106,6 +106,11 @@ test_that("validate_df_with_chain works", {
     factor(dframe_multiple_chains2$Chain, labels = letters[1:4])
   a <- validate_df_with_chain(dframe_multiple_chains2)
   expect_type(a$Chain, "integer")
+
+  # no warning raised when using tibbles (#160)
+  tbl <- tibble::tibble(parameter=rnorm(n=40), Chain=rep(1:4, each=10))
+  a <- validate_df_with_chain(tbl)
+  expect_type(a$Chain, "integer")
 })
 
 test_that("df_with_chain2array works", {


### PR DESCRIPTION
This is the simplest way I could think for fixing #160. All existing (non-visual) tests pass.