### PR TITLE
Issue 216

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     shinystan (>= 2.3.0),
     testthat (>= 2.0.0),
     vdiffr
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Depends:
     R (>= 3.1.0)
 Imports:
     dplyr (>= 0.8.0),
-    ggplot2 (>= 2.2.1),
+    ggplot2 (>= 3.0.0),
     ggridges,
     glue,
     reshape2,

--- a/R/helpers-gg.R
+++ b/R/helpers-gg.R
@@ -97,8 +97,9 @@ space_legend_keys <- function(relative_size = 2, color = "white") {
 
 # set aesthetic mapping for histograms depending on freq argument
 set_hist_aes <- function(freq = TRUE, ...) {
-  if (freq)
+  if (freq) {
     aes_(x = ~ value, ...)
-  else
-    aes_(x = ~ value, y = ~ ..density.., ...)
+  } else {
+    aes_(x = ~ value, y = ~ stat(density), ...)
+  }
 }

--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -301,26 +301,30 @@ mcmc_violin <- function(x,
 
 
 
+
 # internal -----------------------------------------------------------------
 .mcmc_hist <- function(x,
-                      pars = character(),
-                      regex_pars = character(),
-                      transformations = list(),
-                      facet_args = list(),
-                      binwidth = NULL,
-                      breaks = NULL,
-                      by_chain = FALSE,
-                      freq = TRUE,
-                      ...) {
+                       pars = character(),
+                       regex_pars = character(),
+                       transformations = list(),
+                       facet_args = list(),
+                       binwidth = NULL,
+                       breaks = NULL,
+                       by_chain = FALSE,
+                       freq = TRUE,
+                       ...) {
   x <- prepare_mcmc_array(x, pars, regex_pars, transformations)
-  if (by_chain && !has_multiple_chains(x))
+
+  if (by_chain && !has_multiple_chains(x)) {
     STOP_need_multiple_chains()
+  }
 
   data <- melt_mcmc(x, value.name = "value")
   n_param <- num_params(data)
 
-  graph <- ggplot(data, set_hist_aes(freq)) +
+  graph <- ggplot(data, aes(x = ~ value)) +
     geom_histogram(
+      set_hist_aes(freq),
       fill = get_color("mid"),
       color = get_color("mid_highlight"),
       size = .25,
@@ -336,15 +340,19 @@ mcmc_violin <- function(x,
       graph <- graph + do.call("facet_wrap", facet_args)
     }
   } else {
-    facet_args[["facets"]] <- if (n_param > 1)
-      "Chain ~ Parameter" else "Chain ~ ."
+    facet_args[["facets"]] <- if (n_param > 1) {
+      "Chain ~ Parameter"
+    } else {
+      "Chain ~ ."
+    }
     graph <- graph +
       do.call("facet_grid", facet_args) +
       force_axes_in_facets()
   }
 
-  if (n_param == 1)
+  if (n_param == 1) {
     graph <- graph + xlab(levels(data$Parameter))
+  }
 
   graph +
     dont_expand_y_axis(c(0.005, 0)) +
@@ -405,8 +413,8 @@ mcmc_violin <- function(x,
     geom_args[["color"]] <- get_color("mid_highlight")
   }
 
-  graph <- ggplot(data, mapping = do.call("aes_", aes_mapping))  +
-      do.call(geom_fun, geom_args)
+  graph <- ggplot(data, mapping = do.call("aes_", aes_mapping)) +
+    do.call(geom_fun, geom_args)
 
   if (!violin) {
     graph <- graph + dont_expand_x_axis()

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -60,7 +60,7 @@
 #' color_scheme_set("brightblue")
 #' mcmc_intervals(x)
 #' mcmc_intervals(x, pars = c("beta[1]", "beta[2]"))
-#' mcmc_areas(x, regex_pars = "beta\\\[[1-3]\\\]",  prob = 0.8) +
+#' mcmc_areas(x, regex_pars = "beta\\[[1-3]\\]",  prob = 0.8) +
 #'  ggplot2::labs(
 #'    title = "Posterior distributions",
 #'    subtitle = "with medians and 80% intervals"

--- a/R/mcmc-scatterplots.R
+++ b/R/mcmc-scatterplots.R
@@ -220,17 +220,17 @@ mcmc_hex <- function(x,
 #'
 #' # pairs plots
 #' # default of condition=NULL implies splitting chains between upper and lower panels
-#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\[[1,4]\\]",
 #'            off_diag_args = list(size = 1, alpha = 0.5))
 #'
 #' # change to density plots instead of histograms and hex plots instead of
 #' # scatterplots
-#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\[[1,4]\\]",
 #'            diag_fun = "dens", off_diag_fun = "hex")
 #'
 #' # plot chain 1 above diagonal and chains 2, 3, and 4 below
 #' color_scheme_set("brightblue")
-#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+#' mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\[[1,4]\\]",
 #'            diag_fun = "dens", off_diag_fun = "hex",
 #'            condition = pairs_condition(chains = list(1, 2:4)))
 #' }

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -323,17 +323,17 @@ color_scheme_set("purple")
 
 # pairs plots
 # default of condition=NULL implies splitting chains between upper and lower panels
-mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\\[[1,4]\\\\]",
            off_diag_args = list(size = 1, alpha = 0.5))
 
 # change to density plots instead of histograms and hex plots instead of
 # scatterplots
-mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\\[[1,4]\\\\]",
            diag_fun = "dens", off_diag_fun = "hex")
 
 # plot chain 1 above diagonal and chains 2, 3, and 4 below
 color_scheme_set("brightblue")
-mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\[[1,4]\\\]",
+mcmc_pairs(x, pars = "alpha", regex_pars = "beta\\\\[[1,4]\\\\]",
            diag_fun = "dens", off_diag_fun = "hex",
            condition = pairs_condition(chains = list(1, 2:4)))
 }

--- a/tests/figs/mcmc-distributions/mcmc-hist-default.svg
+++ b/tests/figs/mcmc-distributions/mcmc-hist-default.svg
@@ -1,0 +1,345 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0'>
+    <rect x='8.97' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='18.90' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='25.53' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='32.15' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='38.78' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='45.40' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='52.03' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='58.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='65.28' y='135.38' width='6.63' height='136.20' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='71.90' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='78.53' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='85.15' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='91.78' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='98.40' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='105.03' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='111.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='118.28' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='124.90' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='131.53' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='138.15' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='144.78' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='151.40' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='158.03' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='164.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='171.28' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='177.90' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='184.53' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='191.15' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='197.78' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='204.40' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='211.03' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ=='>
+    <rect x='8.97' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='18.90' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='25.53' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='32.15' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='38.78' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='45.40' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='52.03' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='58.65' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='65.28' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='71.90' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='78.53' y='403.81' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='85.15' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='91.78' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='98.40' y='353.37' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='105.03' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='111.65' y='403.81' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='118.28' y='328.14' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='124.90' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='131.53' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='138.15' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='144.78' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='151.40' y='454.26' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='158.03' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='164.65' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='171.28' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='177.90' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='184.53' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='191.15' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='197.78' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='204.40' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='211.03' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ='>
+    <rect x='252.18' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='262.12' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='268.74' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='275.37' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='281.99' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='288.62' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='295.24' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='301.87' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='308.49' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='315.12' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='321.74' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='328.37' y='95.02' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='334.99' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='341.62' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='348.24' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='354.87' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='361.49' y='69.80' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='368.12' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='374.74' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='381.37' y='120.24' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='387.99' y='95.02' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='394.62' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='401.24' y='69.80' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='407.87' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='414.49' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='421.12' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='427.74' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='434.37' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='440.99' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='447.62' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='454.24' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx'>
+    <rect x='252.18' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='262.12' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='268.74' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='275.37' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='281.99' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='288.62' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='295.24' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='301.87' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='308.49' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='315.12' y='493.24' width='6.63' height='61.91' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='321.74' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='328.37' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='334.99' y='493.24' width='6.63' height='61.91' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='341.62' y='451.96' width='6.63' height='103.18' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='348.24' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='354.87' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='361.49' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='368.12' y='328.14' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='374.74' y='451.96' width='6.63' height='103.18' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='381.37' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='387.99' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='394.62' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='401.24' y='431.33' width='6.63' height='123.82' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='407.87' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='414.49' y='410.69' width='6.63' height='144.46' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='421.12' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='427.74' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='434.37' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='440.99' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='447.62' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='454.24' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ='>
+    <rect x='495.40' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='505.33' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='511.96' y='129.70' width='6.63' height='141.88' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='518.58' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='525.21' y='186.45' width='6.63' height='85.13' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='531.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='538.46' y='186.45' width='6.63' height='85.13' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='545.08' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='551.71' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='558.33' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='564.96' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='571.58' y='129.70' width='6.63' height='141.88' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='578.21' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='584.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='591.46' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='598.08' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='604.71' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='611.33' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='617.96' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='624.58' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='631.21' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='637.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='644.46' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='651.08' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='657.71' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='664.33' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='670.96' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='677.58' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='684.21' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='690.83' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='697.46' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnw1NTYuMjh8MzI3LjAx'>
+    <rect x='495.40' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8MzI3LjAxfDMwOC4wNQ=='>
+    <rect x='8.97' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOC45N3wyMjcuNTl8MzI3LjAxfDMwOC4wNQ==)'><text x='111.68' y='321.06' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V4</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXwzMjcuMDF8MzA4LjA1'>
+    <rect x='252.18' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUyLjE4fDQ3MC44MXwzMjcuMDF8MzA4LjA1)'><text x='354.89' y='321.06' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V5</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnwzMjcuMDF8MzA4LjA1'>
+    <rect x='495.40' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8NDMuNDR8MjQuNDk='>
+    <rect x='8.97' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOC45N3wyMjcuNTl8NDMuNDR8MjQuNDk=)'><text x='111.68' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXw0My40NHwyNC40OQ=='>
+    <rect x='252.18' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUyLjE4fDQ3MC44MXw0My40NHwyNC40OQ==)'><text x='354.89' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V2</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnw0My40NHwyNC40OQ=='>
+    <rect x='495.40' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk1LjQwfDcxNC4wMnw0My40NHwyNC40OQ==)'><text x='598.11' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V3</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='8.97,556.28 227.59,556.28 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.44,559.27 44.44,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='83.01,559.27 83.01,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='121.59,559.27 121.59,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='160.17,559.27 160.17,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='198.75,559.27 198.75,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='40.44' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='79.02' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='119.19' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='157.77' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='196.35' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='252.18,556.28 470.81,556.28 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='317.68,559.27 317.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='384.68,559.27 384.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='451.68,559.27 451.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='313.69' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='382.28' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='449.28' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='8.97,272.72 227.59,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='38.45,275.70 38.45,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='73.40,275.70 73.40,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='108.34,275.70 108.34,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='143.29,275.70 143.29,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='178.23,275.70 178.23,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='213.17,275.70 213.17,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='34.46' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='69.41' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='105.94' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='140.89' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='175.83' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='210.77' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<polyline points='252.18,272.72 470.81,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='289.94,275.70 289.94,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='330.68,275.70 330.68,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='371.43,275.70 371.43,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='412.18,275.70 412.18,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='452.93,275.70 452.93,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='285.94' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='326.69' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.03' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='409.78' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='450.53' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='495.40,272.72 714.02,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='507.47,275.70 507.47,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='581.52,275.70 581.52,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='655.58,275.70 655.58,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='503.48' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='579.12' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='653.18' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='495.40,272.72 495.40,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='252.18,272.72 252.18,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='252.18,556.28 252.18,327.01 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='8.97,272.72 8.97,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='8.97,556.28 8.97,327.01 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='8.97' y='15.40' style='font-size: 14.40px; font-family: Liberation Serif;' textLength='116.33px' lengthAdjust='spacingAndGlyphs'>mcmc_hist (default)</text></g>
+</svg>

--- a/tests/figs/mcmc-distributions/mcmc-hist-freq.svg
+++ b/tests/figs/mcmc-distributions/mcmc-hist-freq.svg
@@ -1,0 +1,345 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0'>
+    <rect x='8.97' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='18.90' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='25.53' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='32.15' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='38.78' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='45.40' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='52.03' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='58.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='65.28' y='135.38' width='6.63' height='136.20' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='71.90' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='78.53' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='85.15' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='91.78' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='98.40' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='105.03' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='111.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='118.28' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='124.90' y='112.68' width='6.63' height='158.90' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='131.53' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='138.15' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='144.78' y='203.48' width='6.63' height='68.10' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='151.40' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='158.03' y='180.78' width='6.63' height='90.80' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='164.65' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='171.28' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='177.90' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='184.53' y='226.18' width='6.63' height='45.40' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='191.15' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='197.78' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='204.40' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<rect x='211.03' y='248.88' width='6.63' height='22.70' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8MjcyLjcyfDQzLjQ0)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ=='>
+    <rect x='8.97' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='18.90' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='25.53' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='32.15' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='38.78' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='45.40' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='52.03' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='58.65' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='65.28' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='71.90' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='78.53' y='403.81' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='85.15' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='91.78' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='98.40' y='353.37' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='105.03' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='111.65' y='403.81' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='118.28' y='328.14' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='124.90' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='131.53' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='138.15' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='144.78' y='378.59' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='151.40' y='454.26' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='158.03' y='429.03' width='6.63' height='126.11' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='164.65' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='171.28' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='177.90' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='184.53' y='479.48' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='191.15' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='197.78' y='529.93' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='204.40' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<rect x='211.03' y='504.70' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpOC45N3wyMjcuNTl8NTU2LjI4fDMyNy4wMQ==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ='>
+    <rect x='252.18' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='262.12' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='268.74' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='275.37' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='281.99' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='288.62' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='295.24' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='301.87' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='308.49' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='315.12' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='321.74' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='328.37' y='95.02' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='334.99' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='341.62' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='348.24' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='354.87' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='361.49' y='69.80' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='368.12' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='374.74' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='381.37' y='120.24' width='6.63' height='151.34' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='387.99' y='95.02' width='6.63' height='176.56' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='394.62' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='401.24' y='69.80' width='6.63' height='201.78' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='407.87' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='414.49' y='246.36' width='6.63' height='25.22' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='421.12' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='427.74' y='195.91' width='6.63' height='75.67' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='434.37' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='440.99' y='170.69' width='6.63' height='100.89' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='447.62' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='454.24' y='221.13' width='6.63' height='50.45' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXwyNzIuNzJ8NDMuNDQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx'>
+    <rect x='252.18' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='262.12' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='268.74' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='275.37' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='281.99' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='288.62' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='295.24' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='301.87' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='308.49' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='315.12' y='493.24' width='6.63' height='61.91' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='321.74' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='328.37' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='334.99' y='493.24' width='6.63' height='61.91' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='341.62' y='451.96' width='6.63' height='103.18' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='348.24' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='354.87' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='361.49' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='368.12' y='328.14' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='374.74' y='451.96' width='6.63' height='103.18' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='381.37' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='387.99' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='394.62' y='369.42' width='6.63' height='185.73' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='401.24' y='431.33' width='6.63' height='123.82' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='407.87' y='555.15' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='414.49' y='410.69' width='6.63' height='144.46' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='421.12' y='472.60' width='6.63' height='82.55' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='427.74' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='434.37' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='440.99' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='447.62' y='513.87' width='6.63' height='41.27' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<rect x='454.24' y='534.51' width='6.63' height='20.64' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpMjUyLjE4fDQ3MC44MXw1NTYuMjh8MzI3LjAx)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ='>
+    <rect x='495.40' y='43.44' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<rect x='505.33' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='511.96' y='129.70' width='6.63' height='141.88' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='518.58' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='525.21' y='186.45' width='6.63' height='85.13' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='531.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='538.46' y='186.45' width='6.63' height='85.13' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='545.08' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='551.71' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='558.33' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='564.96' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='571.58' y='129.70' width='6.63' height='141.88' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='578.21' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='584.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='591.46' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='598.08' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='604.71' y='72.95' width='6.63' height='198.63' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='611.33' y='101.33' width='6.63' height='170.25' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='617.96' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='624.58' y='44.58' width='6.63' height='227.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='631.21' y='158.08' width='6.63' height='113.50' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='637.83' y='214.83' width='6.63' height='56.75' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='644.46' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='651.08' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='657.71' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='664.33' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='670.96' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='677.58' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='684.21' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='690.83' y='271.58' width='6.63' height='0.00' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<rect x='697.46' y='243.20' width='6.63' height='28.38' style='stroke-width: 0.53; stroke: #005B96; stroke-linecap: square; stroke-linejoin: miter; fill: #6497B1;' clip-path='url(#cpNDk1LjQwfDcxNC4wMnwyNzIuNzJ8NDMuNDQ=)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnw1NTYuMjh8MzI3LjAx'>
+    <rect x='495.40' y='327.01' width='218.63' height='229.27' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8MzI3LjAxfDMwOC4wNQ=='>
+    <rect x='8.97' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOC45N3wyMjcuNTl8MzI3LjAxfDMwOC4wNQ==)'><text x='111.68' y='321.06' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V4</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXwzMjcuMDF8MzA4LjA1'>
+    <rect x='252.18' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUyLjE4fDQ3MC44MXwzMjcuMDF8MzA4LjA1)'><text x='354.89' y='321.06' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V5</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnwzMjcuMDF8MzA4LjA1'>
+    <rect x='495.40' y='308.05' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpOC45N3wyMjcuNTl8NDMuNDR8MjQuNDk='>
+    <rect x='8.97' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpOC45N3wyMjcuNTl8NDMuNDR8MjQuNDk=)'><text x='111.68' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V1</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpMjUyLjE4fDQ3MC44MXw0My40NHwyNC40OQ=='>
+    <rect x='252.18' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjUyLjE4fDQ3MC44MXw0My40NHwyNC40OQ==)'><text x='354.89' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V2</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<defs>
+  <clipPath id='cpNDk1LjQwfDcxNC4wMnw0My40NHwyNC40OQ=='>
+    <rect x='495.40' y='24.49' width='218.63' height='18.95' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDk1LjQwfDcxNC4wMnw0My40NHwyNC40OQ==)'><text x='598.11' y='37.50' style='font-size: 10.80px; fill: #1A1A1A; font-family: Liberation Serif;' textLength='13.20px' lengthAdjust='spacingAndGlyphs'>V3</text></g>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='8.97,556.28 227.59,556.28 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='44.44,559.27 44.44,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='83.01,559.27 83.01,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='121.59,559.27 121.59,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='160.17,559.27 160.17,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='198.75,559.27 198.75,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='40.44' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='79.02' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='119.19' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='157.77' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='196.35' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='252.18,556.28 470.81,556.28 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='317.68,559.27 317.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='384.68,559.27 384.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='451.68,559.27 451.68,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='313.69' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='382.28' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='449.28' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='8.97,272.72 227.59,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='38.45,275.70 38.45,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='73.40,275.70 73.40,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='108.34,275.70 108.34,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='143.29,275.70 143.29,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='178.23,275.70 178.23,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='213.17,275.70 213.17,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='34.46' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='69.41' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='105.94' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='140.89' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='175.83' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='210.77' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>3</text></g>
+<polyline points='252.18,272.72 470.81,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='289.94,275.70 289.94,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='330.68,275.70 330.68,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='371.43,275.70 371.43,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='412.18,275.70 412.18,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='452.93,275.70 452.93,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='285.94' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='326.69' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='369.03' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='409.78' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='450.53' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='495.40,272.72 714.02,272.72 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='507.47,275.70 507.47,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='581.52,275.70 581.52,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='655.58,275.70 655.58,272.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='503.48' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='579.12' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='653.18' y='284.38' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<polyline points='495.40,272.72 495.40,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='252.18,272.72 252.18,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='252.18,556.28 252.18,327.01 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='8.97,272.72 8.97,43.44 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='8.97,556.28 8.97,327.01 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='8.97' y='15.40' style='font-size: 14.40px; font-family: Liberation Serif;' textLength='99.53px' lengthAdjust='spacingAndGlyphs'>mcmc_hist (freq)</text></g>
+</svg>

--- a/tests/testthat/test-mcmc-distributions.R
+++ b/tests/testthat/test-mcmc-distributions.R
@@ -105,3 +105,14 @@ test_that("mcmc_* throws error if 1 chain but multiple chains required", {
   expect_error(mcmc_violin(dframe), "requires multiple chains")
   expect_error(mcmc_violin(arr1chain), "requires multiple chains")
 })
+
+test_that("mcmc_hist renders correctly", {
+  testthat::skip_on_cran()
+
+  p_base <- mcmc_hist(vdiff_dframe)
+  vdiffr::expect_doppelganger("mcmc_hist (default)", p_base)
+
+  p_freq <- mcmc_hist(vdiff_dframe, freq = TRUE)
+  vdiffr::expect_doppelganger("mcmc_hist (freq)", p_inner)
+})
+

--- a/tests/testthat/test-mcmc-distributions.R
+++ b/tests/testthat/test-mcmc-distributions.R
@@ -113,6 +113,6 @@ test_that("mcmc_hist renders correctly", {
   vdiffr::expect_doppelganger("mcmc_hist (default)", p_base)
 
   p_freq <- mcmc_hist(vdiff_dframe, freq = TRUE)
-  vdiffr::expect_doppelganger("mcmc_hist (freq)", p_inner)
+  vdiffr::expect_doppelganger("mcmc_hist (freq)", p_freq)
 })
 


### PR DESCRIPTION
Fixes #216. 

- tweaks aesthetics call to `mcmc_hist()` to resolve #216
- updates `set_hist_aes()` to use `stat()` syntax
- update min version of ggplot2 to support `stat()`
- adds visual tests for `mcmc_hist()`
- fixes an unrelated issue about escaping in regular expressions that was causing errors when the examples were run