### PR TITLE
allow changing size of ridgelines

### DIFF
--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -245,6 +245,8 @@ mcmc_intervals <- function(x,
 
 #' @rdname MCMC-intervals
 #' @export
+#' @param size For `mcmc_areas()` and `mcmc_areas_ridges()`, the size of the
+#'   ridgelines.
 mcmc_areas <- function(x,
                        pars = character(),
                        regex_pars = character(),
@@ -255,6 +257,7 @@ mcmc_areas <- function(x,
                        prob_outer = 1,
                        point_est = c("median", "mean", "none"),
                        rhat = numeric(),
+                       size = NULL,
                        bw = NULL,
                        adjust = NULL,
                        kernel = NULL,
@@ -330,6 +333,12 @@ mcmc_areas <- function(x,
     fill = NA
   )
 
+  if (!is.null(size)) {
+    args_bottom$size <- size
+    args_outer$size <- size
+    args_inner$size <- size
+  }
+
   if (color_by_rhat) {
     args_bottom$mapping <- args_bottom$mapping %>%
       modify_aes_(color = ~ rhat_rating)
@@ -401,6 +410,7 @@ mcmc_areas_ridges <- function(x,
                              ...,
                              prob_outer = 1,
                              prob = 1,
+                             size = NULL,
                              bw = NULL, adjust = NULL, kernel = NULL,
                              n_dens = NULL) {
   check_ignored_arguments(...)
@@ -431,6 +441,9 @@ mcmc_areas_ridges <- function(x,
     fill = NA,
     stat = "identity"
   )
+  if (!is.null(size)) {
+    args_outer$size <- size
+  }
 
   layer_outer <- do.call(ggridges::geom_density_ridges, args_outer)
 

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -33,6 +33,7 @@ mcmc_areas(
   prob_outer = 1,
   point_est = c("median", "mean", "none"),
   rhat = numeric(),
+  size = NULL,
   bw = NULL,
   adjust = NULL,
   kernel = NULL,
@@ -47,6 +48,7 @@ mcmc_areas_ridges(
   ...,
   prob_outer = 1,
   prob = 1,
+  size = NULL,
   bw = NULL,
   adjust = NULL,
   kernel = NULL,
@@ -161,6 +163,9 @@ default is \code{"equal area"}, setting the density curves to have the same
 area. With \code{"equal height"}, the curves are scaled so that the highest
 points across the curves are the same height. The method \code{"scaled height"} tries a compromise between to the two: the heights from
 \code{"equal height"} are scaled using \code{height*sqrt(height)}}
+
+\item{size}{For \code{mcmc_areas()} and \code{mcmc_areas_ridges()}, the size of the
+ridgelines.}
 
 \item{bw, adjust, kernel, n_dens}{Optional arguments passed to
 \code{\link[stats:density]{stats::density()}} to override default kernel density estimation


### PR DESCRIPTION
Based on this issue reported on the forums 

https://discourse.mc-stan.org/t/bayesplot-mcmc-areas-line-and-grid-width-manipulation/16001

I added a `size` argument to `mcmc_areas()` and `mcmc_areas_ridges()` to control the size (thickness) of the ridgelines. 