### PR TITLE
control sizes of intervals and points in mcmc_intervals 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * Added missing `facet_args` argument to `mcmc_rank_overlay()`. (#221, @hhau)
 * Size of points and interval lines can set in 
-  `mcmc_intervals(..., outer_size, inner_size, point_size)`. (#215, #229) 
+  `mcmc_intervals(..., outer_size, inner_size, point_size)`. (#215, #228, #229) 
 
 
 # bayesplot 1.7.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 -->
 
 * Added missing `facet_args` argument to `mcmc_rank_overlay()`. (#221, @hhau)
+* Size of points and interval lines can set in 
+  `mcmc_intervals(..., outer_size, inner_size, point_size)`. (#215, #229) 
 
 
 # bayesplot 1.7.2

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -25,6 +25,9 @@
 #'   `"equal height"` are scaled using `height*sqrt(height)`
 #' @param point_est The point estimate to show. Either `"median"` (the
 #'   default), `"mean"`, or `"none"`.
+#' @param inner_size,outer_size,point_size For `mcmc_intervals()`, the size of
+#'   the inner interval segments, the outer interval segment, and point
+#'   estimate.
 #' @param rhat An optional numeric vector of R-hat estimates, with one element
 #'   per parameter included in `x`. If `rhat` is provided, the intervals/areas
 #'   and point estimates in the resulting plot are colored based on R-hat value.
@@ -160,6 +163,9 @@ mcmc_intervals <- function(x,
                            prob = 0.5,
                            prob_outer = 0.9,
                            point_est = c("median", "mean", "none"),
+                           outer_size = 0.5,
+                           inner_size = 2,
+                           point_size = 4,
                            rhat = numeric()) {
   check_ignored_arguments(...)
 
@@ -184,17 +190,18 @@ mcmc_intervals <- function(x,
 
   args_outer <- list(
     mapping = aes_(x = ~ ll, xend = ~ hh, y = ~ parameter, yend = ~ parameter),
-    color = get_color("mid")
+    color = get_color("mid"),
+    size = outer_size
   )
   args_inner <- list(
     mapping = aes_(x = ~ l, xend = ~ h, y = ~ parameter, yend = ~ parameter),
-    size = 2,
+    size = inner_size,
     show.legend = FALSE
   )
   args_point <- list(
     mapping = aes_(x = ~ m, y = ~ parameter),
     data = data,
-    size = 4,
+    size = point_size,
     shape = 21
   )
 

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -25,9 +25,9 @@
 #'   `"equal height"` are scaled using `height*sqrt(height)`
 #' @param point_est The point estimate to show. Either `"median"` (the
 #'   default), `"mean"`, or `"none"`.
-#' @param inner_size,outer_size,point_size For `mcmc_intervals()`, the size of
-#'   the inner interval segments, the outer interval segment, and point
-#'   estimate.
+#' @param inner_size,outer_size For `mcmc_intervals()`, the size of
+#'   the inner and interval segments, respectively.
+#' @param point_size For `mcmc_intervals()`, the size of point estimate.
 #' @param rhat An optional numeric vector of R-hat estimates, with one element
 #'   per parameter included in `x`. If `rhat` is provided, the intervals/areas
 #'   and point estimates in the resulting plot are colored based on R-hat value.

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -19,6 +19,9 @@ mcmc_intervals(
   prob = 0.5,
   prob_outer = 0.9,
   point_est = c("median", "mean", "none"),
+  outer_size = 0.5,
+  inner_size = 2,
+  point_size = 4,
   rhat = numeric()
 )
 
@@ -150,6 +153,10 @@ default is \code{0.9} for \code{mcmc_intervals()} (90\% interval) and
 
 \item{point_est}{The point estimate to show. Either \code{"median"} (the
 default), \code{"mean"}, or \code{"none"}.}
+
+\item{inner_size, outer_size, point_size}{For \code{mcmc_intervals()}, the size of
+the inner interval segments, the outer interval segment, and point
+estimate.}
 
 \item{rhat}{An optional numeric vector of R-hat estimates, with one element
 per parameter included in \code{x}. If \code{rhat} is provided, the intervals/areas

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -154,9 +154,10 @@ default is \code{0.9} for \code{mcmc_intervals()} (90\% interval) and
 \item{point_est}{The point estimate to show. Either \code{"median"} (the
 default), \code{"mean"}, or \code{"none"}.}
 
-\item{inner_size, outer_size, point_size}{For \code{mcmc_intervals()}, the size of
-the inner interval segments, the outer interval segment, and point
-estimate.}
+\item{inner_size, outer_size}{For \code{mcmc_intervals()}, the size of
+the inner and interval segments, respectively.}
+
+\item{point_size}{For \code{mcmc_intervals()}, the size of point estimate.}
 
 \item{rhat}{An optional numeric vector of R-hat estimates, with one element
 per parameter included in \code{x}. If \code{rhat} is provided, the intervals/areas

--- a/tests/figs/mcmc-intervals/mcmc-intervals-sizes.svg
+++ b/tests/figs/mcmc-intervals/mcmc-intervals-sizes.svg
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ=='>
+    <rect x='23.08' y='24.49' width='690.95' height='531.80' />
+  </clipPath>
+</defs>
+<line x1='371.33' y1='556.28' x2='371.33' y2='24.49' style='stroke-width: 1.07; stroke: #E5E5E5; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='90.05' y1='85.85' x2='644.96' y2='85.85' style='stroke-width: 8.54; stroke: #6497B1; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='170.84' y1='188.12' x2='654.06' y2='188.12' style='stroke-width: 8.54; stroke: #6497B1; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='103.10' y1='290.38' x2='630.07' y2='290.38' style='stroke-width: 8.54; stroke: #6497B1; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='103.46' y1='392.65' x2='627.82' y2='392.65' style='stroke-width: 8.54; stroke: #6497B1; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='83.03' y1='494.92' x2='628.33' y2='494.92' style='stroke-width: 8.54; stroke: #6497B1; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='220.53' y1='85.85' x2='481.38' y2='85.85' style='stroke-width: 10.67; stroke: #03396C; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='251.85' y1='188.12' x2='493.43' y2='188.12' style='stroke-width: 10.67; stroke: #03396C; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='271.41' y1='290.38' x2='508.15' y2='290.38' style='stroke-width: 10.67; stroke: #03396C; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='257.36' y1='392.65' x2='468.24' y2='392.65' style='stroke-width: 10.67; stroke: #03396C; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<line x1='244.57' y1='494.92' x2='453.96' y2='494.92' style='stroke-width: 10.67; stroke: #03396C; stroke-linecap: butt;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<circle cx='353.37' cy='85.85' r='1.42pt' style='stroke-width: 0.71; stroke: #011F4B; fill: #D1E1EC;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<circle cx='393.02' cy='188.12' r='1.42pt' style='stroke-width: 0.71; stroke: #011F4B; fill: #D1E1EC;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<circle cx='407.18' cy='290.38' r='1.42pt' style='stroke-width: 0.71; stroke: #011F4B; fill: #D1E1EC;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<circle cx='366.13' cy='392.65' r='1.42pt' style='stroke-width: 0.71; stroke: #011F4B; fill: #D1E1EC;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<circle cx='364.01' cy='494.92' r='1.42pt' style='stroke-width: 0.71; stroke: #011F4B; fill: #D1E1EC;' clip-path='url(#cpMjMuMDh8NzE0LjAyfDU1Ni4yOHwyNC40OQ==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='23.08,556.28 23.08,24.49 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.98' y='498.06' style='font-size: 9.60px; font-weight: bold; fill: #4D4D4D; font-family: Liberation Serif;' textLength='11.72px' lengthAdjust='spacingAndGlyphs'>V5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.98' y='395.79' style='font-size: 9.60px; font-weight: bold; fill: #4D4D4D; font-family: Liberation Serif;' textLength='11.72px' lengthAdjust='spacingAndGlyphs'>V4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.98' y='293.53' style='font-size: 9.60px; font-weight: bold; fill: #4D4D4D; font-family: Liberation Serif;' textLength='11.72px' lengthAdjust='spacingAndGlyphs'>V3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.98' y='191.26' style='font-size: 9.60px; font-weight: bold; fill: #4D4D4D; font-family: Liberation Serif;' textLength='11.72px' lengthAdjust='spacingAndGlyphs'>V2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='5.98' y='88.99' style='font-size: 9.60px; font-weight: bold; fill: #4D4D4D; font-family: Liberation Serif;' textLength='11.72px' lengthAdjust='spacingAndGlyphs'>V1</text></g>
+<polyline points='20.09,494.92 23.08,494.92 ' style='stroke-width: 2.13; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='20.09,392.65 23.08,392.65 ' style='stroke-width: 2.13; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='20.09,290.38 23.08,290.38 ' style='stroke-width: 2.13; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='20.09,188.12 23.08,188.12 ' style='stroke-width: 2.13; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='20.09,85.85 23.08,85.85 ' style='stroke-width: 2.13; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='23.08,556.28 714.02,556.28 ' style='stroke-width: 0.85; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.39,559.27 60.39,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='215.86,559.27 215.86,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='371.33,559.27 371.33,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='526.80,559.27 526.80,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='682.27,559.27 682.27,556.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='56.39' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='211.86' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='7.98px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='368.93' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='524.40' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='679.87' y='567.94' style='font-size: 9.60px; fill: #4D4D4D; font-family: Liberation Serif;' textLength='4.80px' lengthAdjust='spacingAndGlyphs'>2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='23.08' y='15.40' style='font-size: 14.40px; font-family: Liberation Serif;' textLength='133.09px' lengthAdjust='spacingAndGlyphs'>mcmc_intervals (sizes)</text></g>
+</svg>

--- a/tests/testthat/test-mcmc-intervals.R
+++ b/tests/testthat/test-mcmc-intervals.R
@@ -197,6 +197,9 @@ test_that("mcmc_intervals renders correctly", {
 
   p_mean_points <- mcmc_intervals(vdiff_dframe, point_est = "mean")
   vdiffr::expect_doppelganger("mcmc_intervals (means)", p_mean_points)
+
+  p_sizes <- mcmc_intervals(vdiff_dframe, point_size = 1, inner_size = 5, outer_size = 4)
+  vdiffr::expect_doppelganger("mcmc_intervals (sizes)", p_sizes)
 })
 
 test_that("mcmc_areas renders correctly", {


### PR DESCRIPTION
Closes #215 and #228 

This PR adds the arguments `inner_size`, `outer_size`, and `point_size` to `mcmc_intervals()` to control the size (thickness) of the interval segments and the size of the point estimate. 

Also adds one new vdiffr visual test.