### PR TITLE
mcmc-parcoord: expand x-axis to avoid cutting off label

### DIFF
--- a/R/mcmc-parcoord.R
+++ b/R/mcmc-parcoord.R
@@ -154,6 +154,7 @@ mcmc_parcoord <-
 
     graph +
       scale_x_discrete(expand = c(0,0), labels = levels(draws$Parameter)) +
+      expand_limits(x = nlevels(draws$Parameter) + 0.5) +
       labs(x = NULL, y = NULL)
   }
 

--- a/R/mcmc-parcoord.R
+++ b/R/mcmc-parcoord.R
@@ -154,7 +154,7 @@ mcmc_parcoord <-
 
     graph +
       scale_x_discrete(expand = c(0,0), labels = levels(draws$Parameter)) +
-      expand_limits(x = nlevels(draws$Parameter) + 0.5) +
+      expand_limits(x = nlevels(draws$Parameter) + 0.25) +
       labs(x = NULL, y = NULL)
   }
 


### PR DESCRIPTION
Fixes #238 

Uses `expand_limits()` to expand the right x-axis limit by 0.25 more than the number of parameters to avoid cutting of last parameter name. Here's a before and after using the example draws included with the package (I also checked with longer parameter names and it works ok):

### Before

![parcoord-old](https://user-images.githubusercontent.com/7796803/92769522-0cca7f80-f367-11ea-9940-9697a4cb63ad.png)


### After 

![parcoord-new](https://user-images.githubusercontent.com/7796803/92770322-d5100780-f367-11ea-9dec-31df7aee34bd.png)

