### PR TITLE
Fix y axis for ppc_loo_pit_qq() with 'compare = "normal"'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * On the y axis, `ppc_loo_pit_qq(..., compare = "normal")` now plots standard
   normal quantiles calculated from the PIT values (instead of the standardized
-  PIT values). (#240, #<PR_number>, @fweber144)
+  PIT values). (#240, #243, @fweber144)
 
 * New plotting function `ppc_km_overlay()` for outcome variables that are   
   right-censored. Empirical CCDF estimates of `yrep` are compared with the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 * Items for next release go here
 -->
 
+* On the y axis, `ppc_loo_pit_qq(..., compare = "normal")` now plots standard
+  normal quantiles calculated from the PIT values (instead of the standardized
+  PIT values). (#240, #<PR_number>, @fweber144)
+
 * New plotting function `ppc_km_overlay()` for outcome variables that are   
   right-censored. Empirical CCDF estimates of `yrep` are compared with the 
   Kaplan-Meier estimate of `y`. (#233, #234, @fweber144)

--- a/R/ppc-loo.R
+++ b/R/ppc-loo.R
@@ -42,11 +42,12 @@
 #'  PITs to the standard uniform distribution. Comparing to the uniform is not
 #'  good for extreme probabilities close to 0 and 1, so it can sometimes be
 #'  useful to set the `compare` argument to `"normal"`, which will
-#'  produce a Q-Q plot comparing standardized PIT values to the standard normal
-#'  distribution that can help see the (mis)calibration better for the extreme
-#'  values. However, in most cases we have found that the overlaid density plot
-#'  (`ppc_loo_pit_overlay()`) function will provided a clearer picture of
-#'  calibration problems that the Q-Q plot.
+#'  produce a Q-Q plot comparing standard normal quantiles calculated from the
+#'  PIT values to the theoretical standard normal quantiles. This can help see
+#'  the (mis)calibration better for the extreme values. However, in most cases
+#'  we have found that the overlaid density plot (`ppc_loo_pit_overlay()`)
+#'  function will provide a clearer picture of calibration problems than the
+#'  Q-Q plot.
 #' }
 #' \item{`ppc_loo_intervals()`, `ppc_loo_ribbon()`}{
 #'  Similar to [ppc_intervals()] and [ppc_ribbon()] but the intervals are for
@@ -113,8 +114,9 @@ NULL
 #' @param compare For `ppc_loo_pit_qq()`, a string that can be either
 #'   `"uniform"` or `"normal"`. If `"uniform"` (the default) the Q-Q plot
 #'   compares computed PIT values to the standard uniform distribution. If
-#'   `compare="normal"`, the Q-Q plot compares standardized PIT values to the
-#'   standard normal distribution.
+#'   `compare="normal"`, the Q-Q plot compares standard normal quantiles
+#'   calculated from the PIT values to the theoretical standard normal
+#'   quantiles.
 #' @param trim Passed to [ggplot2::stat_density()].
 #' @template args-density-controls
 ppc_loo_pit_overlay <- function(y,
@@ -220,10 +222,10 @@ ppc_loo_pit_qq <- function(y,
     x_lab <- "Uniform"
     y_lab <- "LOO-PIT"
   } else {
-    pit <- as.vector(scale(pit))
+    pit <- as.vector(stats::qnorm(pit))
     theoretical <- stats::qnorm
     x_lab <- "Normal"
-    y_lab <- "LOO-PIT (standardized)"
+    y_lab <- "LOO-PIT (standard normal quantiles)"
   }
 
   ggplot(data.frame(p = pit)) +

--- a/man/PPC-loo.Rd
+++ b/man/PPC-loo.Rd
@@ -119,8 +119,9 @@ parameters. \code{n_dens} defaults to \code{1024}.}
 \item{compare}{For \code{ppc_loo_pit_qq()}, a string that can be either
 \code{"uniform"} or \code{"normal"}. If \code{"uniform"} (the default) the Q-Q plot
 compares computed PIT values to the standard uniform distribution. If
-\code{compare="normal"}, the Q-Q plot compares standardized PIT values to the
-standard normal distribution.}
+\code{compare="normal"}, the Q-Q plot compares standard normal quantiles
+calculated from the PIT values to the theoretical standard normal
+quantiles.}
 
 \item{psis_object}{If using \strong{loo} version \verb{2.0.0} or greater, an
 object returned by the \code{psis()} function (or by the \code{loo()} function
@@ -184,11 +185,12 @@ the miscalibration with a quantile-quantile (Q-Q) plot comparing the LOO
 PITs to the standard uniform distribution. Comparing to the uniform is not
 good for extreme probabilities close to 0 and 1, so it can sometimes be
 useful to set the \code{compare} argument to \code{"normal"}, which will
-produce a Q-Q plot comparing standardized PIT values to the standard normal
-distribution that can help see the (mis)calibration better for the extreme
-values. However, in most cases we have found that the overlaid density plot
-(\code{ppc_loo_pit_overlay()}) function will provided a clearer picture of
-calibration problems that the Q-Q plot.
+produce a Q-Q plot comparing standard normal quantiles calculated from the
+PIT values to the theoretical standard normal quantiles. This can help see
+the (mis)calibration better for the extreme values. However, in most cases
+we have found that the overlaid density plot (\code{ppc_loo_pit_overlay()})
+function will provide a clearer picture of calibration problems than the
+Q-Q plot.
 }
 \item{\code{ppc_loo_intervals()}, \code{ppc_loo_ribbon()}}{
 Similar to \code{\link[=ppc_intervals]{ppc_intervals()}} and \code{\link[=ppc_ribbon]{ppc_ribbon()}} but the intervals are for

--- a/tests/testthat/test-ppc-loo.R
+++ b/tests/testthat/test-ppc-loo.R
@@ -28,13 +28,13 @@ test_that("ppc_loo_pit gives deprecation warning but still works", {
 
 test_that("ppc_loo_pit_overlay returns ggplot object", {
   expect_gg(p1 <- ppc_loo_pit_overlay(y, yrep, lw, samples = 25))
-  expect_gg(p2 <- ppc_loo_pit_qq(y, yrep, lw, compare = "normal"))
-  expect_equal(p2$labels$x, "Normal")
 })
 
 test_that("ppc_loo_pit_qq returns ggplot object", {
   expect_gg(p1 <- ppc_loo_pit_qq(y, yrep, lw))
   expect_equal(p1$labels$x, "Uniform")
+  expect_gg(p2 <- ppc_loo_pit_qq(y, yrep, lw, compare = "normal"))
+  expect_equal(p2$labels$x, "Normal")
 })
 
 test_that("ppc_loo_pit functions work when pit specified instead of y,yrep,lw", {


### PR DESCRIPTION
This fixes #240. Notes:
* I have updated the documentation as well as possible. But I might have missed some places in the documentation which need to get updated, too.
* I have moved two lines of code in "tests/testthat/test-ppc-loo.R" which I think got misplaced.
