### PR TITLE
Add ref_interval option to mcmc_rank_* functions.

### DIFF
--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -50,7 +50,9 @@ mcmc_rank_overlay(
   facet_args = list(),
   ...,
   n_bins = 20,
-  ref_line = FALSE
+  ref_line = FALSE,
+  ref_interval = FALSE,
+  interval_args = list(width = 0.95, alpha = 0.2)
 )
 
 mcmc_rank_hist(
@@ -61,7 +63,9 @@ mcmc_rank_hist(
   ...,
   facet_args = list(),
   n_bins = 20,
-  ref_line = FALSE
+  ref_line = FALSE,
+  ref_interval = FALSE,
+  interval_args = list(width = 0.95, alpha = 0.2)
 )
 
 mcmc_trace_data(
@@ -172,6 +176,15 @@ of rank-normalized MCMC samples. Defaults to \code{20}.}
 
 \item{ref_line}{For the rank plots, whether to draw a horizontal line at the
 average number of ranks per bin. Defaults to \code{FALSE}.}
+
+\item{ref_interval}{For the rank plots, whether to draw a reference
+uncertainty interval based on the expected distribution of the rank histogram
+bins. Defaults to \code{FALSE}.}
+
+\item{interval_args}{If \code{ref_interval = TRUE}, optional arguments controlling
+the width and alpha of the reference interval. The default is a \verb{95\\\%}
+uncertainty interval plotted with an alpha value of \code{0.2}. This must be a
+list with elements named \code{width} and \code{alpha}.}
 }
 \value{
 The plotting functions return a ggplot object that can be further

--- a/tests/testthat/test-mcmc-traces.R
+++ b/tests/testthat/test-mcmc-traces.R
@@ -33,6 +33,30 @@ test_that("mcmc_trace_highlight throws error if highlight > number of chains", {
   expect_error(mcmc_trace_highlight(arr, pars = "sigma", highlight = 7), "'highlight' is 7")
 })
 
+test_that("mcmc_rank_hist returns a ggplot object", {
+  expect_gg(mcmc_rank_hist(arr, pars = "beta[1]", regex_pars = "x\\:"))
+  expect_gg(mcmc_rank_hist(dframe_multiple_chains))
+  expect_gg(mcmc_rank_hist(chainlist))
+})
+
+test_that("mcmc_rank_overlay returns a ggplot object", {
+  expect_gg(mcmc_rank_overlay(arr, pars = "beta[1]", regex_pars = "x\\:"))
+  expect_gg(mcmc_rank_overlay(dframe_multiple_chains))
+  expect_gg(mcmc_rank_overlay(chainlist))
+})
+
+test_that("mcmc_rank_hist errors if there is only 1 chain", {
+  expect_error(mcmc_rank_hist(mat), "requires multiple")
+  expect_error(mcmc_rank_hist(dframe), "requires multiple chains")
+  expect_error(mcmc_rank_hist(arr1chain), "requires multiple chains")
+})
+
+test_that("mcmc_rank_overlay errors if there is only 1 chain", {
+  expect_error(mcmc_rank_overlay(mat), "requires multiple")
+  expect_error(mcmc_rank_overlay(dframe), "requires multiple chains")
+  expect_error(mcmc_rank_overlay(arr1chain), "requires multiple chains")
+})
+
 # options -----------------------------------------------------------------
 test_that("mcmc_trace options work", {
   expect_gg(g1 <- mcmc_trace(arr, regex_pars = "beta", window = c(5, 10)))
@@ -46,6 +70,43 @@ test_that("mcmc_trace options work", {
   expect_error(mcmc_trace(arr, iter1 = -1))
   expect_error(mcmc_trace(arr, n_warmup = 50, iter1 = 20))
 })
+
+test_that("mcmc_rank_hist options work", {
+  expect_gg(mcmc_rank_hist(arr, regex_pars = "beta", ref_interval = TRUE))
+  expect_gg(
+    mcmc_rank_hist(arr, 
+               regex_pars = "beta", 
+               n_bins = 15,
+               ref_line = TRUE,
+               ref_interval = TRUE,
+               interval_args = list(width = 0.8, alpha = 0.1))
+  )
+})
+
+test_that("mcmc_rank_overlay options work", {
+  expect_gg(mcmc_rank_overlay(arr, regex_pars = "beta", ref_interval = TRUE))
+  expect_gg(
+    mcmc_rank_overlay(arr, 
+               regex_pars = "beta", 
+               n_bins = 15,
+               ref_line = TRUE,
+               ref_interval = TRUE,
+               interval_args = list(width = 0.8, alpha = 0.1))
+  )
+})
+
+test_that("mcmc_rank_* interval_args get validated", {
+  expect_error(
+    mcmc_rank_overlay(arr, 
+               regex_pars = "beta", 
+               n_bins = 15,
+               ref_line = TRUE,
+               ref_interval = TRUE,
+               interval_args = list(with = 0.8, alpha = 0.1)), # intended typo
+    "is not TRUE"
+  )
+})
+
 
 
 # displaying divergences in traceplot -------------------------------------


### PR DESCRIPTION
Not sure if this is something that you've thought about before but decided against, but I quite often want to add an uncertainty interval to the `mcmc_rank_*` functions (not everyone knows how to interpret them yet). Because these are binned rank histograms, we can use the argument employed in the Simulated Bayesian Calibration paper to get appropriate uncertainty intervals. Said intervals are based on the expected distribution of the rank histobins (which follow a binomial distribution).

`mcmc_rank_*` functions default to not drawing this interval, but when it is requested (using `ref_interval = TRUE`), the defaults are a 95% uncertainty interval drawn with `alpha = 0.2`.

Here is the default behaviour:

``` r
library(bayesplot)
#> This is bayesplot version 1.7.2.9000
#> - Online documentation and vignettes at mc-stan.org/bayesplot
#> - bayesplot theme set to bayesplot::theme_default()
#>    * Does _not_ affect other ggplot2 plots
#>    * See ?bayesplot_theme_set for details on theme setting

mcmc_rank_hist(
 example_mcmc_draws(),
 ref_interval = TRUE
)
```

![](https://i.imgur.com/tPG1gZS.png)


And here is a slightly more complicated example, with some very bad draws added:

``` r

n_chain <- 4
n_sample_per_chain <- 5000
n_parameter <- 2
n_total <- n_chain * n_sample_per_chain * n_parameter
n_bins <- 20

ex_samples <- array(
  data = c(rnorm(n_total - 200), rep(1, 200)),
  dim = c(n_sample_per_chain, n_chain, n_parameter),
  dimnames = list(
    Sample = 1 : n_sample_per_chain,
    Chain = 1 : n_chain,
    Parameter = c("theta", "phi")
  )
)

mcmc_rank_overlay(
  ex_samples,
  ref_interval = TRUE
)
```

![](https://i.imgur.com/KDxgHyl.png)

<sup>Created on 2020-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>