### PR TITLE
Require ggfortify for some tests

### DIFF
--- a/tests/testthat/test-ppc-distributions.R
+++ b/tests/testthat/test-ppc-distributions.R
@@ -14,6 +14,7 @@ test_that("ppc_ecdf_overlay returns a ggplot object", {
 })
 
 test_that("ppc_km_overlay returns a ggplot object", {
+  skip_if_not_installed("ggfortify")
   expect_gg(ppc_km_overlay(y, yrep, status_y = status_y, size = 0.5, alpha = 0.2))
   expect_gg(ppc_km_overlay(y2, yrep2, status_y = status_y2))
 })
@@ -155,6 +156,7 @@ test_that("ppc_ecdf_overlay_grouped renders correctly", {
 test_that("ppc_km_overlay renders correctly", {
   testthat::skip_on_cran()
   testthat::skip_if_not_installed("vdiffr")
+  testthat::skip_if_not_installed("ggfortify")
 
   p_base <- ppc_km_overlay(vdiff_y2, vdiff_yrep2, status_y = vdiff_status_y2)
   vdiffr::expect_doppelganger("ppc_km_overlay (default)", p_base)


### PR DESCRIPTION
While working on a different PR, I noticed that I do not have ggfortify installed and tests failed because of that.  This PR skips those tests when ggfortify is not installed.