### PR TITLE
handle posterior's draws objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 inst/doc
 
 tests/testthat/Rplots.pdf
+tests/testthat/_snaps/
 
 .DS_Store
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     ggplot2 (>= 3.0.0),
     ggridges,
     glue,
+    posterior,
     reshape2,
     rlang (>= 0.3.0),
     stats,
@@ -53,7 +54,7 @@ Suggests:
     survival,
     testthat (>= 2.0.0),
     vdiffr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 # bayesplot 1.8.1.9000
 
+* `mcmc_*()` functions now support all draws formats from the **posterior** package. (#277, @Ozan147)
+
 * `mcmc_dens()` and `mcmc_dens_overlay()` gain arguments for controlling the 
   the density calculation. (#258)
   

--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -9,7 +9,9 @@ prepare_mcmc_array <- function(x,
                                pars = character(),
                                regex_pars = character(),
                                transformations = list()) {
-  if (is_df_with_chain(x)) {
+  if (posterior::is_draws(x)) {
+    x <- posterior::as_draws_array(x)
+  } else if (is_df_with_chain(x)) {
     x <- df_with_chain2array(x)
   } else if (is_chain_list(x)) {
     # this will apply to mcmc.list and similar objects

--- a/R/mcmc-overview.R
+++ b/R/mcmc-overview.R
@@ -25,6 +25,8 @@
 #' have already been merged), or a data frame with one column per parameter plus
 #' an additional column `"Chain"` that contains the chain number (an integer)
 #' corresponding to each row in the data frame.
+#' * __draws__: Any of the `draws` formats supported by the
+#' \pkg{\link{posterior}} package.
 #'
 #' __Note__: typically the user should *not* include warmup iterations
 #' in the object passed to **bayesplot** plotting functions, although for

--- a/man-roxygen/args-mcmc-x.R
+++ b/man-roxygen/args-mcmc-x.R
@@ -1,5 +1,8 @@
-#' @param x A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-#'   The [MCMC-overview] page provides details on how to specify each these
-#'   allowed inputs. It is also possible to use an object with an
-#'   `as.array()` method that returns the same kind of 3-D array described on
-#'   the [MCMC-overview] page.
+#' @param x An object containing MCMC draws:
+#' * A 3-D array, matrix, list of matrices, or data frame. The [MCMC-overview]
+#' page provides details on how to specify each these.
+#' * A `draws` object from the \pkg{\link{posterior}} package (e.g.,
+#' `draws_array`, `draws_rvars`, etc.).
+#' * An object with an `as.array()` method that returns the same kind of 3-D
+#' array described on the [MCMC-overview] page.
+#'

--- a/man/MCMC-combos.Rd
+++ b/man/MCMC-combos.Rd
@@ -8,11 +8,15 @@
 mcmc_combo(x, combo = c("dens", "trace"), ..., widths = NULL, gg_theme = NULL)
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{combo}{A character vector with at least two elements. Each element of
 \code{combo} corresponds to a column in the resulting graphic and should be the

--- a/man/MCMC-diagnostics.Rd
+++ b/man/MCMC-diagnostics.Rd
@@ -61,11 +61,15 @@ alternative to \code{binwidth}.}
 \item{ratio}{A vector of \emph{ratios} of effective sample size estimates to
 total sample size. See \code{\link[=neff_ratio]{neff_ratio()}}.}
 
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -31,12 +31,12 @@ mcmc_dens(
   transformations = list(),
   ...,
   facet_args = list(),
-  alpha = 1,
   trim = FALSE,
   bw = NULL,
   adjust = NULL,
   kernel = NULL,
-  n_dens = NULL
+  n_dens = NULL,
+  alpha = 1
 )
 
 mcmc_hist_by_chain(

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -102,11 +102,15 @@ mcmc_violin(
 )
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/man/MCMC-intervals.Rd
+++ b/man/MCMC-intervals.Rd
@@ -99,11 +99,15 @@ mcmc_areas_ridges_data(
 )
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/man/MCMC-overview.Rd
+++ b/man/MCMC-overview.Rd
@@ -26,6 +26,8 @@ frame with one column per parameter (if only a single chain or all chains
 have already been merged), or a data frame with one column per parameter plus
 an additional column \code{"Chain"} that contains the chain number (an integer)
 corresponding to each row in the data frame.
+\item \strong{draws}: Any of the \code{draws} formats supported by the
+\pkg{\link{posterior}} package.
 }
 
 \strong{Note}: typically the user should \emph{not} include warmup iterations

--- a/man/MCMC-parcoord.Rd
+++ b/man/MCMC-parcoord.Rd
@@ -30,11 +30,15 @@ mcmc_parcoord_data(
 parcoord_style_np(div_color = "red", div_size = 0.2, div_alpha = 0.2)
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/man/MCMC-recover.Rd
+++ b/man/MCMC-recover.Rd
@@ -41,11 +41,15 @@ mcmc_recover_hist(
 )
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{true}{A numeric vector of "true" values of the parameters in \code{x}.
 There should be one value in \code{true} for each parameter included in

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -71,11 +71,15 @@ pairs_style_np(
 pairs_condition(chains = NULL, draws = NULL, nuts = NULL)
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/man/MCMC-traces.Rd
+++ b/man/MCMC-traces.Rd
@@ -76,11 +76,15 @@ mcmc_trace_data(
 )
 }
 \arguments{
-\item{x}{A 3-D array, matrix, list of matrices, or data frame of MCMC draws.
-The \link{MCMC-overview} page provides details on how to specify each these
-allowed inputs. It is also possible to use an object with an
-\code{as.array()} method that returns the same kind of 3-D array described on
-the \link{MCMC-overview} page.}
+\item{x}{An object containing MCMC draws:
+\itemize{
+\item A 3-D array, matrix, list of matrices, or data frame. The \link{MCMC-overview}
+page provides details on how to specify each these.
+\item A \code{draws} object from the \pkg{\link{posterior}} package (e.g.,
+\code{draws_array}, \code{draws_rvars}, etc.).
+\item An object with an \code{as.array()} method that returns the same kind of 3-D
+array described on the \link{MCMC-overview} page.
+}}
 
 \item{pars}{An optional character vector of parameter names. If neither
 \code{pars} nor \code{regex_pars} is specified then the default is to use \emph{all}

--- a/tests/testthat/data-for-mcmc-tests.R
+++ b/tests/testthat/data-for-mcmc-tests.R
@@ -3,6 +3,8 @@ set.seed(8420)
 # Prepare input objects
 arr <- array(rnorm(4000), dim = c(100, 4, 10))
 arr1chain <- arr[, 1, , drop = FALSE]
+drawsarr <- posterior::example_draws()
+drawsarr1chain <- drawsarr[, 1, , drop = FALSE]
 mat <- matrix(rnorm(1000), nrow = 100, ncol = 10)
 dframe <- as.data.frame(mat)
 chainlist <- list(matrix(rnorm(1000), nrow = 100, ncol = 10),
@@ -16,6 +18,7 @@ chainlist1chain <- chainlist[1]
 
 # one parameter
 arr1 <- arr[, , 1, drop = FALSE]
+drawsarr1 <- drawsarr[, , 1, drop = FALSE]
 mat1 <- mat[, 1, drop = FALSE]
 dframe1 <- dframe[, 1, drop = FALSE]
 chainlist1 <- list(chainlist[[1]][, 1, drop=FALSE],

--- a/tests/testthat/test-mcmc-combo.R
+++ b/tests/testthat/test-mcmc-combo.R
@@ -7,6 +7,7 @@ test_that("mcmc_combo returns a gtable object", {
   expect_gtable(mcmc_combo(arr, regex_pars = "beta"))
   expect_gtable(mcmc_combo(arr, regex_pars = "beta",
                            gg_theme = ggplot2::theme_dark()))
+  expect_gtable(mcmc_combo(drawsarr, regex_pars = "theta"))
   expect_gtable(mcmc_combo(mat, regex_pars = "beta",
                            binwidth = 1/20, combo = c("dens", "hist"),
                            facet_args = list(nrow = 2)))
@@ -18,6 +19,7 @@ test_that("mcmc_combo returns a gtable object", {
                            combo = c("trace", "hist")))
 
   expect_gtable(mcmc_combo(arr1, pars = "(Intercept)"))
+  expect_gtable(mcmc_combo(drawsarr1))
   expect_gtable(mcmc_combo(mat1))
   expect_gtable(mcmc_combo(dframe1))
 })
@@ -26,6 +28,9 @@ test_that("mcmc_combo returns a gtable object", {
 test_that("mcmc_combo throws error if 1 chain but multiple chains required", {
   expect_error(mcmc_combo(arr1chain, regex_pars = "beta",
                combo = c("trace_highlight", "dens")),
+               "requires multiple chains")
+  expect_error(mcmc_combo(drawsarr1chain, regex_pars = "theta",
+                          combo = c("trace_highlight", "dens")),
                "requires multiple chains")
   expect_error(mcmc_combo(mat, regex_pars = "beta",
                combo = c("trace_highlight", "hist")),

--- a/tests/testthat/test-mcmc-distributions.R
+++ b/tests/testthat/test-mcmc-distributions.R
@@ -11,11 +11,14 @@ get_palette <- function(ggplot, n) {
 test_that("mcmc_hist returns a ggplot object", {
   expect_gg(mcmc_hist(arr, pars = "beta[1]", regex_pars = "x\\:"))
   expect_gg(mcmc_hist(arr1chain, regex_pars = "beta"))
+  expect_gg(mcmc_hist(drawsarr, pars = "theta[1]"))
+  expect_gg(mcmc_hist(drawsarr1chain, regex_pars = "theta"))
   expect_gg(mcmc_hist(mat))
   expect_gg(mcmc_hist(dframe))
   expect_gg(mcmc_hist(dframe_multiple_chains))
 
   expect_gg(mcmc_hist(arr1))
+  expect_gg(mcmc_hist(drawsarr1))
   expect_gg(mcmc_hist(mat1))
   expect_gg(mcmc_hist(dframe1))
 })
@@ -23,6 +26,8 @@ test_that("mcmc_hist returns a ggplot object", {
 test_that("mcmc_dens returns a ggplot object", {
   expect_gg(mcmc_dens(arr, pars = "beta[2]", regex_pars = "x\\:"))
   expect_gg(mcmc_dens(arr1chain, regex_pars = "beta"))
+  expect_gg(mcmc_hist(drawsarr, pars = "theta[1]"))
+  expect_gg(mcmc_hist(drawsarr1chain, regex_pars = "theta"))
   expect_gg(mcmc_dens(mat))
 
   expect_gg(mcmc_dens(dframe, transformations = list(sigma = function(x) x^2)))
@@ -33,6 +38,7 @@ test_that("mcmc_dens returns a ggplot object", {
   ))
 
   expect_gg(mcmc_dens(arr1))
+  expect_gg(mcmc_hist(drawsarr1))
   expect_gg(mcmc_dens(mat1))
   expect_gg(mcmc_dens(dframe1))
 })
@@ -92,18 +98,22 @@ test_that("mcmc_* throws error if 1 chain but multiple chains required", {
   expect_error(mcmc_hist_by_chain(mat), "requires multiple chains")
   expect_error(mcmc_hist_by_chain(dframe), "requires multiple chains")
   expect_error(mcmc_hist_by_chain(arr1chain), "requires multiple chains")
+  expect_error(mcmc_hist_by_chain(drawsarr1chain), "requires multiple chains")
 
   expect_error(mcmc_dens_overlay(mat), "requires multiple chains")
   expect_error(mcmc_dens_overlay(dframe), "requires multiple chains")
   expect_error(mcmc_dens_overlay(arr1chain), "requires multiple chains")
+  expect_error(mcmc_dens_overlay(drawsarr1chain), "requires multiple chains")
 
   expect_error(mcmc_dens_chains(mat), "requires multiple chains")
   expect_error(mcmc_dens_chains(dframe), "requires multiple chains")
   expect_error(mcmc_dens_chains(arr1chain), "requires multiple chains")
+  expect_error(mcmc_dens_chains(drawsarr1chain), "requires multiple chains")
 
   expect_error(mcmc_violin(mat), "requires multiple chains")
   expect_error(mcmc_violin(dframe), "requires multiple chains")
   expect_error(mcmc_violin(arr1chain), "requires multiple chains")
+  expect_error(mcmc_violin(drawsarr1chain), "requires multiple chains")
 })
 
 

--- a/tests/testthat/test-mcmc-scatter-and-parcoord.R
+++ b/tests/testthat/test-mcmc-scatter-and-parcoord.R
@@ -17,6 +17,7 @@ if (requireNamespace("rstanarm", quietly = TRUE)) {
 test_that("mcmc_scatter returns a ggplot object", {
   expect_gg(mcmc_scatter(arr, pars = c("beta[1]", "beta[2]")))
   expect_gg(mcmc_scatter(arr1chain, regex_pars = "beta", size = 3, alpha = 0.5))
+  expect_gg(mcmc_scatter(drawsarr, pars = c("theta[1]", "theta[2]")))
   expect_gg(mcmc_scatter(mat, pars = c("sigma", "(Intercept)")))
   expect_gg(mcmc_scatter(dframe, regex_pars = "x:[2,4]"))
   expect_gg(mcmc_scatter(dframe_multiple_chains,
@@ -26,7 +27,9 @@ test_that("mcmc_scatter returns a ggplot object", {
 test_that("mcmc_scatter throws error if number of parameters is not 2", {
   expect_error(mcmc_scatter(arr, pars = c("sigma", "beta[1]", "beta[2]")), "exactly 2 parameters")
   expect_error(mcmc_scatter(arr, pars = "sigma"), "exactly 2 parameters")
+  expect_error(mcmc_scatter(drawsarr, pars = "mu"), "exactly 2 parameters")
   expect_error(mcmc_scatter(arr1), "exactly 2 parameters")
+  expect_error(mcmc_scatter(drawsarr1), "exactly 2 parameters")
   expect_error(mcmc_scatter(mat1), "exactly 2 parameters")
 })
 
@@ -46,12 +49,14 @@ test_that("mcmc_hex returns a ggplot object", {
   skip_if_not_installed("hexbin")
   expect_gg(mcmc_hex(arr, pars = c("beta[1]", "beta[2]")))
   expect_gg(mcmc_hex(arr1chain, regex_pars = "beta", binwidth = c(.5,.5)))
+  expect_gg(mcmc_hex(drawsarr, pars = c("theta[1]", "theta[2]")))
 })
 
 test_that("mcmc_hex throws error if number of parameters is not 2", {
   skip_if_not_installed("hexbin")
   expect_error(mcmc_hex(arr, pars = c("sigma", "beta[1]", "beta[2]")), "exactly 2 parameters")
   expect_error(mcmc_hex(arr, pars = "sigma"), "exactly 2 parameters")
+  expect_error(mcmc_hex(drawsarr, pars = "mu"), "exactly 2 parameters")
   expect_error(mcmc_hex(arr1), "exactly 2 parameters")
   expect_error(mcmc_hex(mat1), "exactly 2 parameters")
 })
@@ -69,8 +74,10 @@ test_that("mcmc_pairs returns a bayesplot_grid object", {
                                    diag_fun = "dens", off_diag_fun = "hex",
                                    diag_args = list(trim = FALSE),
                                    off_diag_args = list(binwidth = c(0.5, 0.5))))
+  expect_bayesplot_grid(mcmc_pairs(drawsarr, pars = "mu", regex_pars = "theta"))
 
   expect_bayesplot_grid(suppressWarnings(mcmc_pairs(arr1chain, regex_pars = "beta")))
+  expect_bayesplot_grid(suppressWarnings(mcmc_pairs(drawsarr1chain, regex_pars = "theta")))
   expect_bayesplot_grid(suppressWarnings(mcmc_pairs(mat, pars = c("(Intercept)", "sigma"))))
   expect_bayesplot_grid(suppressWarnings(mcmc_pairs(dframe, pars = c("(Intercept)", "sigma"))))
   expect_bayesplot_grid(mcmc_pairs(dframe_multiple_chains, regex_pars = "beta"))


### PR DESCRIPTION
Closes #274 

Provides the flexibility to use all [posterior](https://github.com/stan-dev/posterior) `draws` objects as inputs to plotting functions by casting them to `draws_array` within `prepare_mcmc_array()`.