### PR TITLE
Check intervals numeric

### DIFF
--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -864,6 +864,8 @@ compute_interval_density <- function(x, interval_width = 1, n_dens = 1024,
 }
 
 check_interval_widths <- function(prob, prob_outer) {
+  if (!(is.numeric(prob) && is.numeric(prob_outer)))
+    abort("`prob` and `prob_outer` must be numeric")
   if (prob < 0 || prob > 1 || prob_outer < 0 || prob_outer > 1)
     abort("`prob` and `prob_outer` must be in [0,1].")
   if (prob_outer < prob) {


### PR DESCRIPTION
Setting `prob <- FALSE`, e.g. in `mcmc_intervals`, does not raise an error but has unintended consequences.