### PR TITLE
add 'bins' argument to many histogram plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: bayesplot
 Type: Package
 Title: Plotting for Bayesian Models
-Version: 1.10.0.9000
-Date: 2022-11-16
+Version: 1.10.0.9001
+Date: 2023-03-16
 Authors@R: c(person("Jonah", "Gabry", role = c("aut", "cre"), email = "jsg2201@columbia.edu"),
              person("Tristan", "Mahr", role = "aut"),
              person("Paul-Christian", "Bürkner", role = "ctb"),
@@ -55,7 +55,7 @@ Suggests:
     survival,
     testthat (>= 2.0.0),
     vdiffr (>= 1.0.2)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/mcmc-diagnostics.R
+++ b/R/mcmc-diagnostics.R
@@ -171,7 +171,7 @@ mcmc_rhat <- function(rhat, ..., size = NULL) {
 
 #' @rdname MCMC-diagnostics
 #' @export
-mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL, breaks = NULL) {
+mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL, bins = NULL, breaks = NULL) {
   check_ignored_arguments(...)
   data <- mcmc_rhat_data(rhat)
 
@@ -185,6 +185,7 @@ mcmc_rhat_hist <- function(rhat, ..., binwidth = NULL, breaks = NULL) {
       linewidth = 0.25,
       na.rm = TRUE,
       binwidth = binwidth,
+      bins = bins,
       breaks = breaks
     ) +
     scale_color_diagnostic("rhat") +
@@ -261,7 +262,7 @@ mcmc_neff <- function(ratio, ..., size = NULL) {
 
 #' @rdname MCMC-diagnostics
 #' @export
-mcmc_neff_hist <- function(ratio, ..., binwidth = NULL, breaks = NULL) {
+mcmc_neff_hist <- function(ratio, ..., binwidth = NULL, bins = NULL, breaks = NULL) {
   check_ignored_arguments(...)
   data <- mcmc_neff_data(ratio)
 
@@ -275,6 +276,7 @@ mcmc_neff_hist <- function(ratio, ..., binwidth = NULL, breaks = NULL) {
       linewidth = 0.25,
       na.rm = TRUE,
       binwidth = binwidth,
+      bins = bins,
       breaks = breaks) +
     scale_color_diagnostic("neff") +
     scale_fill_diagnostic("neff") +

--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -115,6 +115,7 @@ mcmc_hist <- function(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE,
   alpha = 1
@@ -127,6 +128,7 @@ mcmc_hist <- function(
     transformations = transformations,
     facet_args = facet_args,
     binwidth = binwidth,
+    bins = bins,
     breaks = breaks,
     by_chain = FALSE,
     freq = freq,
@@ -180,6 +182,7 @@ mcmc_hist_by_chain <- function(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE,
   alpha = 1
 ) {
@@ -191,6 +194,7 @@ mcmc_hist_by_chain <- function(
     transformations = transformations,
     facet_args = facet_args,
     binwidth = binwidth,
+    bins = bins,
     by_chain = TRUE,
     freq = freq,
     alpha = alpha,
@@ -369,6 +373,7 @@ mcmc_violin <- function(
   transformations = list(),
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   by_chain = FALSE,
   freq = TRUE,
@@ -392,6 +397,7 @@ mcmc_violin <- function(
       size = .25,
       na.rm = TRUE,
       binwidth = binwidth,
+      bins = bins,
       breaks = breaks,
       alpha = alpha
     )

--- a/R/mcmc-recover.R
+++ b/R/mcmc-recover.R
@@ -303,6 +303,7 @@ mcmc_recover_hist <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL) {
 
     check_ignored_arguments(...)
@@ -327,6 +328,7 @@ mcmc_recover_hist <-
         color = get_color("lh"),
         linewidth = 0.25,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       geom_vline(

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -362,6 +362,7 @@ ppc_hist <-
            yrep,
            ...,
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
@@ -375,6 +376,7 @@ ppc_hist <-
       geom_histogram(
         linewidth = 0.25,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       scale_fill_ppc() +

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -119,6 +119,7 @@ ppc_error_hist <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
 
@@ -135,6 +136,7 @@ ppc_error_hist <-
         color = get_color("lh"),
         size = 0.25,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       xlab(error_label()) +

--- a/R/ppc-test-statistics.R
+++ b/R/ppc-test-statistics.R
@@ -102,6 +102,7 @@ ppc_stat <-
            stat = "mean",
            ...,
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     stopifnot(length(stat) == 1)
@@ -127,6 +128,7 @@ ppc_stat <-
         linewidth = 0.25,
         na.rm = TRUE,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       geom_vline(

--- a/R/ppd-distributions.R
+++ b/R/ppd-distributions.R
@@ -156,6 +156,7 @@ ppd_hist <-
   function(ypred,
            ...,
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
@@ -169,6 +170,7 @@ ppd_hist <-
       geom_histogram(
         size = 0.25,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       scale_color_ppd() +

--- a/R/ppd-test-statistics.R
+++ b/R/ppd-test-statistics.R
@@ -36,6 +36,7 @@ ppd_stat <-
            stat = "mean",
            ...,
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     stopifnot(length(stat) == 1)
@@ -59,6 +60,7 @@ ppd_stat <-
         linewidth = 0.25,
         na.rm = TRUE,
         binwidth = binwidth,
+        bins = bins,
         breaks = breaks
       ) +
       scale_color_ppd(guide = "none") +

--- a/man-roxygen/args-hist.R
+++ b/man-roxygen/args-hist.R
@@ -1,6 +1,7 @@
 #' @param binwidth Passed to [ggplot2::geom_histogram()] to override
 #'   the default binwidth.
-#'
+#' @param bins Passed to [ggplot2::geom_histogram()] to override
+#'   the default binwidth.
 #' @param breaks Passed to [ggplot2::geom_histogram()] as an
 #'   alternative to `binwidth`.
 #'

--- a/man/MCMC-diagnostics.Rd
+++ b/man/MCMC-diagnostics.Rd
@@ -14,13 +14,13 @@
 \usage{
 mcmc_rhat(rhat, ..., size = NULL)
 
-mcmc_rhat_hist(rhat, ..., binwidth = NULL, breaks = NULL)
+mcmc_rhat_hist(rhat, ..., binwidth = NULL, bins = NULL, breaks = NULL)
 
 mcmc_rhat_data(rhat, ...)
 
 mcmc_neff(ratio, ..., size = NULL)
 
-mcmc_neff_hist(ratio, ..., binwidth = NULL, breaks = NULL)
+mcmc_neff_hist(ratio, ..., binwidth = NULL, bins = NULL, breaks = NULL)
 
 mcmc_neff_data(ratio, ...)
 
@@ -53,6 +53,9 @@ default size (for \code{mcmc_rhat()}, \code{mcmc_neff()}) or
 \code{\link[ggplot2:geom_path]{ggplot2::geom_line()}}'s default line width (for \code{mcmc_acf()}).}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/MCMC-distributions.Rd
+++ b/man/MCMC-distributions.Rd
@@ -19,6 +19,7 @@ mcmc_hist(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE,
   alpha = 1
@@ -47,6 +48,7 @@ mcmc_hist_by_chain(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE,
   alpha = 1
 )
@@ -157,6 +159,9 @@ then \strong{bayesplot} may use \code{scales="free"} as the default (depending
 on the plot) instead of the \strong{ggplot2} default of \code{scales="fixed"}.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/MCMC-recover.Rd
+++ b/man/MCMC-recover.Rd
@@ -37,6 +37,7 @@ mcmc_recover_hist(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL
 )
 }
@@ -87,6 +88,9 @@ default), \code{"mean"}, or \code{"none"}.}
 appearance of plotted points.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -69,7 +69,15 @@ ppc_ecdf_overlay_grouped(
 
 ppc_dens(y, yrep, ..., trim = FALSE, size = 0.5, alpha = 1)
 
-ppc_hist(y, yrep, ..., binwidth = NULL, breaks = NULL, freq = TRUE)
+ppc_hist(
+  y,
+  yrep,
+  ...,
+  binwidth = NULL,
+  bins = NULL,
+  breaks = NULL,
+  freq = TRUE
+)
 
 ppc_freqpoly(y, yrep, ..., binwidth = NULL, freq = TRUE, size = 0.5, alpha = 1)
 
@@ -158,6 +166,9 @@ passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}. If \code{discre
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/PPC-errors.Rd
+++ b/man/PPC-errors.Rd
@@ -18,6 +18,7 @@ ppc_error_hist(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )
@@ -83,6 +84,8 @@ on the plot) instead of the \strong{ggplot2} default of \code{scales="fixed"}.}
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
+\item{bins}{For \code{ppc_error_binned()}, the number of bins to use (approximately).}
+
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an
 alternative to \code{binwidth}.}
 
@@ -104,8 +107,6 @@ opacity of the shaded region indicating the 2-SE bounds.}
 
 \item{x}{A numeric vector the same length as \code{y} to use as the x-axis
 variable.}
-
-\item{bins}{For \code{ppc_error_binned()}, the number of bins to use (approximately).}
 }
 \value{
 A ggplot object that can be further customized using the \strong{ggplot2} package.

--- a/man/PPC-test-statistics.Rd
+++ b/man/PPC-test-statistics.Rd
@@ -17,6 +17,7 @@ ppc_stat(
   stat = "mean",
   ...,
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )
@@ -79,6 +80,9 @@ then generic naming is used in the legend.}
 \item{...}{Currently unused.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/PPD-distributions.Rd
+++ b/man/PPD-distributions.Rd
@@ -37,7 +37,7 @@ ppd_ecdf_overlay(
 
 ppd_dens(ypred, ..., trim = FALSE, size = 0.5, alpha = 1)
 
-ppd_hist(ypred, ..., binwidth = NULL, breaks = NULL, freq = TRUE)
+ppd_hist(ypred, ..., binwidth = NULL, bins = NULL, breaks = NULL, freq = TRUE)
 
 ppd_freqpoly(ypred, ..., binwidth = NULL, freq = TRUE, size = 0.5, alpha = 1)
 
@@ -83,6 +83,9 @@ passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}. If \code{discre
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/man/PPD-test-statistics.Rd
+++ b/man/PPD-test-statistics.Rd
@@ -16,6 +16,7 @@ ppd_stat(
   stat = "mean",
   ...,
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )
@@ -70,6 +71,9 @@ then generic naming is used in the legend.}
 \item{...}{Currently unused.}
 
 \item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
 the default binwidth.}
 
 \item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an

--- a/tests/testthat/test-mcmc-distributions.R
+++ b/tests/testthat/test-mcmc-distributions.R
@@ -15,6 +15,7 @@ test_that("mcmc_hist returns a ggplot object", {
   expect_gg(mcmc_hist(drawsarr1chain, regex_pars = "theta", binwidth = 0.1))
   expect_gg(mcmc_hist(mat, binwidth = 0.1))
   expect_gg(mcmc_hist(dframe, binwidth = 0.1))
+  expect_gg(mcmc_hist(dframe, bins = 10))
   expect_gg(mcmc_hist(dframe_multiple_chains, binwidth = 0.1))
 
   expect_gg(mcmc_hist(arr1, binwidth = 0.1))


### PR DESCRIPTION
This PR adds the `bins` argument to a lot of histogram plots. So far, you could only customize the histogram bins via `binwidth` and `breaks`, but the often most simple and convenient option to just specify the number of bins via the `bins` argument of `ggplot2::geom_histogram` was missing so far. This PR resolves this issue. 