### PR TITLE
better loo_pit_qq plots

### DIFF
--- a/R/ppc-loo.R
+++ b/R/ppc-loo.R
@@ -189,7 +189,7 @@ ppc_loo_pit_overlay <- function(y,
       geom_line(
         aes(color = "y"),
         data = function(x) dplyr::filter(x, .data$is_y),
-        linewidth = 1,
+       linewidth = 1,
         lineend = "round",
         na.rm = TRUE) +
       scale_x_continuous(
@@ -326,21 +326,23 @@ ppc_loo_pit_qq <- function(y,
     y_lab <- "LOO-PIT (standard normal quantiles)"
   }
 
-  ggplot(data.frame(p = pit)) +
+  qq <- ggplot(data.frame(p = pit)) +
     geom_qq(
       aes(sample = .data$p),
       distribution = theoretical,
       color = get_color("m"),
       size = size,
       alpha = alpha) +
-    geom_qq_line(
-      aes(sample = .data$p),
+    geom_abline(
       linetype = 2,
-      distribution = theoretical,
-      color = "black",
-      fullrange = FALSE) +
+      color = "black") +
     bayesplot_theme_get() +
     labs(x = x_lab, y = y_lab)
+  if (compare == "uniform") {
+    qq + lims(x=c(0,1), y=c(0,1))
+  } else {
+    qq
+  }
 }
 
 

--- a/tests/testthat/_snaps/ppc-loo/ppc-loo-pit-qq-default.svg
+++ b/tests/testthat/_snaps/ppc-loo/ppc-loo-pit-qq-default.svg
@@ -20,136 +20,130 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMzguNDR8NzE0LjAyfDI0Ljg1fDU0Mi4zMA=='>
-    <rect x='38.44' y='24.85' width='675.58' height='517.45' />
+  <clipPath id='cpNDMuNzh8NzE0LjAyfDI0Ljg1fDU0Mi4zMA=='>
+    <rect x='43.78' y='24.85' width='670.24' height='517.45' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMzguNDR8NzE0LjAyfDI0Ljg1fDU0Mi4zMA==)'>
-<circle cx='69.15' cy='505.32' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='75.35' cy='505.22' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='81.56' cy='501.75' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='87.76' cy='497.56' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='93.96' cy='490.58' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='100.17' cy='488.13' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='106.37' cy='482.64' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='112.58' cy='481.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='118.78' cy='477.88' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='124.98' cy='477.74' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='131.19' cy='477.45' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='137.39' cy='476.23' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='143.59' cy='476.17' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='149.80' cy='475.05' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='156.00' cy='472.26' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='162.21' cy='472.00' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='168.41' cy='471.92' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='174.61' cy='471.18' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='180.82' cy='469.24' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='187.02' cy='462.71' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='193.22' cy='461.97' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='199.43' cy='457.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='205.63' cy='453.83' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='211.83' cy='447.60' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='218.04' cy='444.51' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='224.24' cy='444.00' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='230.45' cy='441.34' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='236.65' cy='441.03' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='242.85' cy='432.67' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='249.06' cy='430.34' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='255.26' cy='428.95' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='261.46' cy='423.14' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='267.67' cy='422.57' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='273.87' cy='421.39' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='280.08' cy='416.06' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='286.28' cy='412.98' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='292.48' cy='412.31' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='298.69' cy='410.42' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='304.89' cy='408.16' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='311.09' cy='407.97' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='317.30' cy='407.53' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='323.50' cy='406.62' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='329.70' cy='402.60' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='335.91' cy='402.42' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='342.11' cy='399.92' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='348.32' cy='397.14' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='354.52' cy='396.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='360.72' cy='393.07' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='366.93' cy='391.86' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='373.13' cy='390.58' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='379.33' cy='389.67' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='385.54' cy='382.06' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='391.74' cy='379.50' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='397.94' cy='378.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='404.15' cy='377.38' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='410.35' cy='364.50' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='416.56' cy='364.19' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='422.76' cy='358.14' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='428.96' cy='355.34' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='435.17' cy='351.64' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='441.37' cy='348.12' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='447.57' cy='346.07' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='453.78' cy='341.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='459.98' cy='327.27' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='466.19' cy='321.20' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='472.39' cy='309.55' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='478.59' cy='307.71' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='484.80' cy='301.80' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='491.00' cy='296.98' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='497.20' cy='296.65' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='503.41' cy='296.39' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='509.61' cy='296.26' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='515.81' cy='293.28' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='522.02' cy='292.82' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='528.22' cy='291.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='534.43' cy='291.16' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='540.63' cy='276.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='546.83' cy='270.83' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='553.04' cy='267.93' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='559.24' cy='266.80' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='565.44' cy='258.88' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='571.65' cy='256.22' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='577.85' cy='255.62' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='584.06' cy='251.05' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='590.26' cy='247.20' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='596.46' cy='241.42' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='602.67' cy='234.42' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='608.87' cy='231.72' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='615.07' cy='227.12' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='621.28' cy='222.12' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='627.48' cy='221.15' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='633.68' cy='209.99' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='639.89' cy='191.36' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='646.09' cy='179.46' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='652.30' cy='168.35' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='658.50' cy='163.37' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='664.70' cy='152.36' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='670.91' cy='151.18' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='677.11' cy='150.21' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<circle cx='683.31' cy='48.38' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
-<polyline points='69.15,518.78 683.31,217.10 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<g clip-path='url(#cpNDMuNzh8NzE0LjAyfDI0Ljg1fDU0Mi4zMA==)'>
+<circle cx='77.29' cy='518.78' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='83.39' cy='518.64' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='89.48' cy='513.29' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='95.57' cy='506.83' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='101.67' cy='496.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='107.76' cy='492.30' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='113.85' cy='483.85' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='119.95' cy='482.79' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='126.04' cy='476.50' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='132.13' cy='476.30' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='138.22' cy='475.84' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='144.32' cy='473.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='150.41' cy='473.87' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='156.50' cy='472.14' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='162.60' cy='467.84' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='168.69' cy='467.44' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='174.78' cy='467.32' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='180.88' cy='466.18' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='186.97' cy='463.20' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='193.06' cy='453.13' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='199.16' cy='451.99' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='205.25' cy='444.45' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='211.34' cy='439.45' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='217.43' cy='429.84' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='223.53' cy='425.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='229.62' cy='424.30' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='235.71' cy='420.21' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='241.81' cy='419.72' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='247.90' cy='406.85' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='253.99' cy='403.26' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='260.09' cy='401.11' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='266.18' cy='392.15' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='272.27' cy='391.29' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='278.37' cy='389.47' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='284.46' cy='381.25' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='290.55' cy='376.50' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='296.64' cy='375.47' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='302.74' cy='372.56' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='308.83' cy='369.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='314.92' cy='368.79' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='321.02' cy='368.11' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='327.11' cy='366.70' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='333.20' cy='360.50' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='339.30' cy='360.23' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='345.39' cy='356.38' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='351.48' cy='352.10' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='357.58' cy='350.47' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='363.67' cy='345.83' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='369.76' cy='343.96' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='375.86' cy='342.00' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='381.95' cy='340.59' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='388.04' cy='328.86' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='394.13' cy='324.91' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='400.23' cy='324.09' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='406.32' cy='321.65' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='412.41' cy='301.81' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='418.51' cy='301.32' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='424.60' cy='292.00' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='430.69' cy='287.69' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='436.79' cy='281.99' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='442.88' cy='276.57' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='448.97' cy='273.41' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='455.07' cy='265.71' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='461.16' cy='244.43' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='467.25' cy='235.08' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='473.34' cy='217.13' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='479.44' cy='214.29' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='485.53' cy='205.18' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='491.62' cy='197.76' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='497.72' cy='197.26' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='503.81' cy='196.85' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='509.90' cy='196.66' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='516.00' cy='192.06' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='522.09' cy='191.35' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='528.18' cy='190.02' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='534.28' cy='188.80' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='540.37' cy='166.92' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='546.46' cy='157.47' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='552.56' cy='153.01' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='558.65' cy='151.25' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='564.74' cy='139.06' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='570.83' cy='134.95' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='576.93' cy='134.03' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='583.02' cy='126.99' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='589.11' cy='121.06' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='595.21' cy='112.15' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='601.30' cy='101.37' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='607.39' cy='97.20' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='613.49' cy='90.12' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='619.58' cy='82.41' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='625.67' cy='80.92' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<circle cx='631.77' cy='63.71' r='2.49' style='stroke-width: 0.71; stroke: #6497B1; fill: #6497B1;' />
+<line x1='-626.46' y1='1059.75' x2='1384.26' y2='-492.60' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='38.44,542.30 38.44,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
-<text x='33.06' y='508.62' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
-<text x='33.06' y='355.98' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
-<text x='33.06' y='203.33' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.0</text>
-<text x='33.06' y='50.69' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.5</text>
-<polyline points='35.45,505.32 38.44,505.32 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='35.45,352.67 38.44,352.67 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='35.45,200.03 38.44,200.03 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='35.45,47.39 38.44,47.39 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='38.44,542.30 714.02,542.30 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
-<polyline points='66.05,545.29 66.05,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='221.14,545.29 221.14,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='376.23,545.29 376.23,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='531.32,545.29 531.32,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<polyline points='686.42,545.29 686.42,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
-<text x='66.05' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
-<text x='221.14' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
-<text x='376.23' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>
-<text x='531.32' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.75</text>
-<text x='686.42' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>1.00</text>
-<text x='376.23' y='567.53' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='42.01px' lengthAdjust='spacingAndGlyphs'>Uniform</text>
+<polyline points='43.78,542.30 43.78,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<text x='38.40' y='522.09' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='38.40' y='404.49' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='38.40' y='286.88' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='38.40' y='169.28' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='38.40' y='51.68' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<polyline points='40.79,518.78 43.78,518.78 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.79,401.18 43.78,401.18 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.79,283.58 43.78,283.58 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.79,165.98 43.78,165.98 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.79,48.38 43.78,48.38 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='43.78,542.30 714.02,542.30 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<polyline points='74.25,545.29 74.25,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='226.57,545.29 226.57,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='378.90,545.29 378.90,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='531.23,545.29 531.23,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.56,545.29 683.56,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<text x='74.25' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.00</text>
+<text x='226.57' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.25</text>
+<text x='378.90' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.50</text>
+<text x='531.23' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>0.75</text>
+<text x='683.56' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='18.69px' lengthAdjust='spacingAndGlyphs'>1.00</text>
+<text x='378.90' y='567.53' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='42.01px' lengthAdjust='spacingAndGlyphs'>Uniform</text>
 <text transform='translate(14.24,283.58) rotate(-90)' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='48.02px' lengthAdjust='spacingAndGlyphs'>LOO-PIT</text>
-<text x='38.44' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='154.52px' lengthAdjust='spacingAndGlyphs'>ppc_loo_pit_qq (default)</text>
+<text x='43.78' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='154.52px' lengthAdjust='spacingAndGlyphs'>ppc_loo_pit_qq (default)</text>
 </g>
 </svg>


### PR DESCRIPTION
EDIT: fixes #296 

loo_pit_qq plots were using geom_qq + geom_qq_line, but that line was not useful in these plots. geom_qq_line is useful if the mean and scale of the data can be different and only the shape matters. When plotting PITs, they are constrained in range [0,1] and the qq's should follow the diagonal. When plotting with `compare='normal'`, the reference line should stiill be diagonal. This PR fixes the line and sets axis limit for the uniform qq-plot to be (0,1). Examples of old and new plots

Old uniform, as the line is diagonal it makes it more difficult to see the relevant difference:
![image](https://github.com/stan-dev/bayesplot/assets/6705400/61bdcad1-e254-4db6-a8e9-3ea2f75bce19)

New uniform:
![image](https://github.com/stan-dev/bayesplot/assets/6705400/cf41875e-5603-4a6a-be59-abcbab00d991)

Old normal:
![image](https://github.com/stan-dev/bayesplot/assets/6705400/60da9f3e-b15a-4e7e-875f-7d3ac8e79915)

New normal:
![image](https://github.com/stan-dev/bayesplot/assets/6705400/6430a394-956a-4214-878b-f913849f4dc6)
