### PR TITLE
Update for new ggplot2 release

### DIFF
--- a/R/bayesplot-ggplot-themes.R
+++ b/R/bayesplot-ggplot-themes.R
@@ -54,8 +54,7 @@ theme_default <-
         panel.spacing = unit(1.5, "lines"),
         legend.position = "right",
         legend.background = element_blank(),
-        legend.text = element_text(size = 13),
-        legend.text.align = 0,
+        legend.text = element_text(size = 13, hjust = 0),
         legend.key = element_blank()
       )
   }

--- a/R/bayesplot-helpers.R
+++ b/R/bayesplot-helpers.R
@@ -333,7 +333,11 @@ calc_intervals <- function(x, p, med = TRUE, ...) {
 #'   equivalent to using `legend_none()`.
 #'
 legend_move <- function(position = "right") {
-  theme(legend.position = position)
+  if (is.numeric(position) && "legend.position.inside" %in% fn_fmls_names(theme)) {
+    theme(legend.position = "inside", legend.position.inside = position)
+  } else {
+    theme(legend.position = position)
+  }
 }
 #' @rdname bayesplot-helpers
 #' @export

--- a/R/mcmc-diagnostics.R
+++ b/R/mcmc-diagnostics.R
@@ -519,7 +519,7 @@ drop_NAs_and_warn <- function(x) {
     plot_data <- acf_data(x = x, lags = lags)
 
     if (num_chains(x) > 1) {
-      facet_args$facets <- "Chain ~ Parameter"
+      facet_args$rows <- "Chain ~ Parameter"
       facet_fun <- "facet_grid"
     } else { # 1 chain
       facet_args$facets <- "Parameter"

--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -409,7 +409,7 @@ mcmc_violin <- function(
       graph <- graph + do.call("facet_wrap", facet_args)
     }
   } else {
-    facet_args[["facets"]] <- if (n_param > 1) {
+    facet_args[["rows"]] <- if (n_param > 1) {
       "Chain ~ Parameter"
     } else {
       "Chain ~ ."

--- a/R/mcmc-traces.R
+++ b/R/mcmc-traces.R
@@ -393,6 +393,7 @@ mcmc_rank_hist <- function(x,
   # Otherwise, use a grid.
   if (n_param > 1) {
     facet_f <- facet_grid
+    names(facet_args)[names(facet_args) == "facets"] <- "rows"
   } else {
     facet_f <- facet_wrap
     facet_args[["nrow"]] <- facet_args[["nrow"]] %||% 1

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -398,7 +398,7 @@ error_hist_facets <-
 
     if (grouped) {
       facet_fun <- "facet_grid"
-      facet_args[["facets"]] <- rep_id ~ group
+      facet_args[["rows"]] <- rep_id ~ group
     } else {
       facet_fun <- "facet_wrap"
       facet_args[["facets"]] <- ~ rep_id

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -110,7 +110,10 @@ test_that("legend_move returns correct theme object", {
 
   pos <- legend_move(c(0.25, 0.5))
   expect_s3_class(pos, "theme")
-  expect_equivalent(pos, list(legend.position = c(0.25, 0.5)))
+  expect_equivalent(
+    pos$legend.position.inside %||% pos$legend.position,
+    c(0.25, 0.5)
+  )
   expect_false(attr(pos, "complete"))
 })
 test_that("legend_text returns correct theme object", {


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break bayesplot.

This PR updates the `legend_move()` function to deal with the incoming changes.
Additionally, it removes the deprecated use of `legend.text.align` and `facet_grid(facet = ...)`.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help bayesplot get out a fix if necessary.