### PR TITLE
Add `bins` and `breaks` arguments to more histogram and hex plots

### DIFF
--- a/R/mcmc-diagnostics-nuts.R
+++ b/R/mcmc-diagnostics-nuts.R
@@ -127,15 +127,16 @@ NULL
 
 #' @rdname MCMC-nuts
 #' @export
-#' @param binwidth An optional value passed to [ggplot2::geom_histogram()] to
-#'   override the default binwidth.
+#' @template args-hist
 #'
 mcmc_nuts_acceptance <-
   function(x,
            lp,
            chain = NULL,
            ...,
-           binwidth = NULL) {
+           binwidth = NULL,
+           bins = NULL,
+           breaks = NULL) {
     suggested_package("gridExtra")
     check_ignored_arguments(...)
 
@@ -160,7 +161,9 @@ mcmc_nuts_acceptance <-
         color = get_color("lh"),
         linewidth = 0.25,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        bins = bins,
+        breaks = breaks
       ) +
       bayesplot_theme_get()
 
@@ -209,7 +212,9 @@ mcmc_nuts_acceptance <-
           color = NA,
           alpha = 0.5,
           na.rm = TRUE,
-          binwidth = binwidth
+          binwidth = binwidth,
+          bins = bins,
+          breaks = breaks
         )
 
       chain_scatter_data <- data.frame(
@@ -417,6 +422,8 @@ mcmc_nuts_energy <-
   function(x,
            ...,
            binwidth = NULL,
+           bins = NULL,
+           breaks = NULL,
            alpha = 0.5,
            merge_chains = FALSE) {
     check_ignored_arguments(...)
@@ -446,7 +453,9 @@ mcmc_nuts_energy <-
         ),
         linewidth = 0.25,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        bins = bins,
+        breaks = breaks
       ) +
       geom_histogram(
         aes(
@@ -457,7 +466,9 @@ mcmc_nuts_energy <-
         linewidth = 0.25,
         na.rm = TRUE,
         alpha = alpha,
-        binwidth = binwidth
+        binwidth = binwidth,
+        bins = bins,
+        breaks = breaks
       ) +
       scale_fill_manual("", values = fills, labels = aes_labs) +
       scale_color_manual("", values = clrs, labels = aes_labs) +

--- a/R/mcmc-scatterplots.R
+++ b/R/mcmc-scatterplots.R
@@ -13,7 +13,7 @@
 #' @param ... Currently ignored.
 #' @param size,alpha For `mcmc_scatter()`, passed to
 #'   [ggplot2::geom_point()] to control the appearance of the points.
-#' @param binwidth For `mcmc_hex()`, an optional numeric vector of
+#' @param bins,binwidth For `mcmc_hex()`, an optional numeric vector of
 #'   *length two* passed to [ggplot2::geom_hex()] to override the
 #'   default binwidth in both the vertical and horizontal directions.
 #'
@@ -156,6 +156,7 @@ mcmc_hex <- function(x,
                      regex_pars = character(),
                      transformations = list(),
                      ...,
+                     bins = 30,
                      binwidth = NULL) {
   suggested_package("scales")
   suggested_package("hexbin")
@@ -166,6 +167,7 @@ mcmc_hex <- function(x,
     regex_pars = regex_pars,
     transformations = transformations,
     hex = TRUE,
+    bins = bins,
     binwidth = binwidth,
     size = NULL,
     alpha = NULL
@@ -641,6 +643,7 @@ pairs_condition <- function(chains = NULL, draws = NULL, nuts = NULL) {
                           hex = FALSE,
                           size = 2.5,
                           alpha = 0.8,
+                          bins = 30,
                           binwidth = NULL,
                           np = NULL,
                           np_style = scatter_style_np()) {
@@ -702,6 +705,7 @@ pairs_condition <- function(chains = NULL, draws = NULL, nuts = NULL) {
     graph <- graph +
       geom_hex(
         aes(fill = scales::rescale(after_stat(density))),
+        bins = bins,
         binwidth = binwidth
       ) +
       scale_fill_gradientn(

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -402,6 +402,7 @@ ppc_freqpoly <-
            yrep,
            ...,
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE,
            size = 0.5,
            alpha = 1) {
@@ -420,6 +421,7 @@ ppc_freqpoly <-
       geom_area(
         stat = "bin",
         binwidth = binwidth,
+        bins = bins,
         linewidth = size,
         alpha = alpha
       ) +
@@ -446,6 +448,7 @@ ppc_freqpoly_grouped <-
            group,
            ...,
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE,
            size = 0.5,
            alpha = 1) {

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -164,6 +164,7 @@ ppc_error_hist_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
 

--- a/R/ppc-test-statistics.R
+++ b/R/ppc-test-statistics.R
@@ -165,6 +165,7 @@ ppc_stat_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
@@ -185,6 +186,7 @@ ppc_stat_freqpoly <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE) {
     stopifnot(length(stat) == 1)
     dots <- list(...)
@@ -208,7 +210,8 @@ ppc_stat_freqpoly <-
         aes(color = "yrep"),
         linewidth = 0.5,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        bins = bins
       ) +
       geom_vline(
         data = dplyr::filter(data, .data$variable == "y"),
@@ -240,6 +243,7 @@ ppc_stat_freqpoly_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
     call <- match.call(expand.dots = FALSE)

--- a/R/ppd-distributions.R
+++ b/R/ppd-distributions.R
@@ -194,6 +194,7 @@ ppd_freqpoly <-
   function(ypred,
            ...,
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE,
            size = 0.5,
            alpha = 1) {
@@ -213,6 +214,7 @@ ppd_freqpoly <-
       geom_area(
         stat = "bin",
         binwidth = binwidth,
+        bins = bins,
         size = size,
         alpha = alpha
       ) +
@@ -238,6 +240,7 @@ ppd_freqpoly_grouped <-
            group,
            ...,
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE,
            size = 0.5,
            alpha = 1) {

--- a/R/ppd-test-statistics.R
+++ b/R/ppd-test-statistics.R
@@ -85,6 +85,7 @@ ppd_stat_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            breaks = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
@@ -104,6 +105,7 @@ ppd_stat_freqpoly <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE) {
     stopifnot(length(stat) == 1)
     dots <- list(...)
@@ -122,7 +124,8 @@ ppd_stat_freqpoly <-
         aes(color = "ypred"),
         linewidth = 0.5,
         na.rm = TRUE,
-        binwidth = binwidth
+        binwidth = binwidth,
+        bins = bins
       ) +
       scale_color_ppd(
         name = stat_legend_title(stat, deparse(substitute(stat))),
@@ -146,6 +149,7 @@ ppd_stat_freqpoly_grouped <-
            ...,
            facet_args = list(),
            binwidth = NULL,
+           bins = NULL,
            freq = TRUE) {
     check_ignored_arguments(...)
     call <- match.call(expand.dots = FALSE)

--- a/man/MCMC-nuts.Rd
+++ b/man/MCMC-nuts.Rd
@@ -10,7 +10,15 @@
 \alias{mcmc_nuts_energy}
 \title{Diagnostic plots for the No-U-Turn-Sampler (NUTS)}
 \usage{
-mcmc_nuts_acceptance(x, lp, chain = NULL, ..., binwidth = NULL)
+mcmc_nuts_acceptance(
+  x,
+  lp,
+  chain = NULL,
+  ...,
+  binwidth = NULL,
+  bins = NULL,
+  breaks = NULL
+)
 
 mcmc_nuts_divergence(x, lp, chain = NULL, ...)
 
@@ -18,7 +26,15 @@ mcmc_nuts_stepsize(x, lp, chain = NULL, ...)
 
 mcmc_nuts_treedepth(x, lp, chain = NULL, ...)
 
-mcmc_nuts_energy(x, ..., binwidth = NULL, alpha = 0.5, merge_chains = FALSE)
+mcmc_nuts_energy(
+  x,
+  ...,
+  binwidth = NULL,
+  bins = NULL,
+  breaks = NULL,
+  alpha = 0.5,
+  merge_chains = FALSE
+)
 }
 \arguments{
 \item{x}{A molten data frame of NUTS sampler parameters, either created by
@@ -39,8 +55,14 @@ is not used by \code{mcmc_nuts_energy()}.}
 
 \item{...}{Currently ignored.}
 
-\item{binwidth}{An optional value passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to
-override the default binwidth.}
+\item{binwidth}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{bins}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} to override
+the default binwidth.}
+
+\item{breaks}{Passed to \code{\link[ggplot2:geom_histogram]{ggplot2::geom_histogram()}} as an
+alternative to \code{binwidth}.}
 
 \item{alpha}{For \code{mcmc_nuts_energy()} only, the transparency (alpha) level
 in \verb{[0,1]} used for the overlaid histogram.}

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -28,6 +28,7 @@ mcmc_hex(
   regex_pars = character(),
   transformations = list(),
   ...,
+  bins = 30,
   binwidth = NULL
 )
 
@@ -134,7 +135,7 @@ arguments controlling the appearance of superimposed points representing
 NUTS diagnostic information. (Note: for \code{pairs_style_np()} the
 \code{size} arguments are interpreted as scaling factors).}
 
-\item{binwidth}{For \code{mcmc_hex()}, an optional numeric vector of
+\item{bins, binwidth}{For \code{mcmc_hex()}, an optional numeric vector of
 \emph{length two} passed to \code{\link[ggplot2:geom_hex]{ggplot2::geom_hex()}} to override the
 default binwidth in both the vertical and horizontal directions.}
 

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -79,7 +79,16 @@ ppc_hist(
   freq = TRUE
 )
 
-ppc_freqpoly(y, yrep, ..., binwidth = NULL, freq = TRUE, size = 0.5, alpha = 1)
+ppc_freqpoly(
+  y,
+  yrep,
+  ...,
+  binwidth = NULL,
+  bins = NULL,
+  freq = TRUE,
+  size = 0.5,
+  alpha = 1
+)
 
 ppc_freqpoly_grouped(
   y,
@@ -87,6 +96,7 @@ ppc_freqpoly_grouped(
   group,
   ...,
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE,
   size = 0.5,
   alpha = 1

--- a/man/PPC-errors.Rd
+++ b/man/PPC-errors.Rd
@@ -30,6 +30,7 @@ ppc_error_hist_grouped(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )

--- a/man/PPC-test-statistics.Rd
+++ b/man/PPC-test-statistics.Rd
@@ -30,6 +30,7 @@ ppc_stat_grouped(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )
@@ -41,6 +42,7 @@ ppc_stat_freqpoly(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE
 )
 
@@ -52,6 +54,7 @@ ppc_stat_freqpoly_grouped(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE
 )
 

--- a/man/PPD-distributions.Rd
+++ b/man/PPD-distributions.Rd
@@ -39,13 +39,22 @@ ppd_dens(ypred, ..., trim = FALSE, size = 0.5, alpha = 1)
 
 ppd_hist(ypred, ..., binwidth = NULL, bins = NULL, breaks = NULL, freq = TRUE)
 
-ppd_freqpoly(ypred, ..., binwidth = NULL, freq = TRUE, size = 0.5, alpha = 1)
+ppd_freqpoly(
+  ypred,
+  ...,
+  binwidth = NULL,
+  bins = NULL,
+  freq = TRUE,
+  size = 0.5,
+  alpha = 1
+)
 
 ppd_freqpoly_grouped(
   ypred,
   group,
   ...,
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE,
   size = 0.5,
   alpha = 1

--- a/man/PPD-test-statistics.Rd
+++ b/man/PPD-test-statistics.Rd
@@ -28,6 +28,7 @@ ppd_stat_grouped(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   breaks = NULL,
   freq = TRUE
 )
@@ -38,6 +39,7 @@ ppd_stat_freqpoly(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE
 )
 
@@ -48,6 +50,7 @@ ppd_stat_freqpoly_grouped(
   ...,
   facet_args = list(),
   binwidth = NULL,
+  bins = NULL,
   freq = TRUE
 )
 


### PR DESCRIPTION
This is a follow-up of #285 and #300.