### PR TITLE
Ensure rank overlay plot starts at 0 even if not all bins present

### DIFF
--- a/tests/testthat/_snaps/mcmc-traces/mcmc-rank-overlay-not-all-bins.svg
+++ b/tests/testthat/_snaps/mcmc-traces/mcmc-rank-overlay-not-all-bins.svg
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjcuMzh8NjU4Ljc2fDI0Ljg1fDU0Mi4zMA=='>
+    <rect x='27.38' y='24.85' width='631.38' height='517.45' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjcuMzh8NjU4Ljc2fDI0Ljg1fDU0Mi4zMA==)'>
+<polyline points='56.08,518.78 84.79,518.78 84.79,518.78 113.50,518.78 113.50,518.78 142.22,518.78 142.22,518.78 170.93,518.78 170.93,518.78 199.64,518.78 199.64,495.26 228.36,495.26 228.36,372.96 257.07,372.96 257.07,264.76 285.78,264.76 285.78,231.83 314.50,231.83 314.50,189.50 343.21,189.50 343.21,184.79 371.92,184.79 371.92,161.27 400.64,161.27 400.64,114.23 429.35,114.23 429.35,123.64 458.06,123.64 458.06,90.71 486.78,90.71 486.78,170.68 515.49,170.68 515.49,147.16 544.20,147.16 544.20,184.79 572.92,184.79 572.92,147.16 601.63,147.16 601.63,198.91 630.06,198.91 630.06,198.91 ' style='stroke-width: 1.07; stroke: #03396C; stroke-linecap: butt;' />
+<polyline points='56.08,48.38 84.79,48.38 84.79,48.38 113.50,48.38 113.50,48.38 142.22,48.38 142.22,48.38 170.93,48.38 170.93,48.38 199.64,48.38 199.64,71.90 228.36,71.90 228.36,194.20 257.07,194.20 257.07,302.40 285.78,302.40 285.78,335.32 314.50,335.32 314.50,377.66 343.21,377.66 343.21,382.37 371.92,382.37 371.92,405.89 400.64,405.89 400.64,452.93 429.35,452.93 429.35,443.52 458.06,443.52 458.06,476.45 486.78,476.45 486.78,396.48 515.49,396.48 515.49,420.00 544.20,420.00 544.20,382.37 572.92,382.37 572.92,420.00 601.63,420.00 601.63,368.25 630.06,368.25 630.06,368.25 ' style='stroke-width: 1.07; stroke: #D1E1EC; stroke-linecap: butt;' />
+<line x1='27.38' y1='542.30' x2='658.76' y2='542.30' style='stroke-width: 0.85; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='27.38,542.30 27.38,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<text x='22.00' y='522.09' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='22.00' y='404.49' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='22.00' y='286.88' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='22.00' y='169.28' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='22.00' y='51.68' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='24.39,518.78 27.38,518.78 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='24.39,401.18 27.38,401.18 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='24.39,283.58 27.38,283.58 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='24.39,165.98 27.38,165.98 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='24.39,48.38 27.38,48.38 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='27.38,542.30 658.76,542.30 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<polyline points='55.79,545.29 55.79,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='199.36,545.29 199.36,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='342.92,545.29 342.92,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='486.49,545.29 486.49,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='630.06,545.29 630.06,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<text x='55.79' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='199.36' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>500</text>
+<text x='342.92' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='21.36px' lengthAdjust='spacingAndGlyphs'>1000</text>
+<text x='486.49' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='21.36px' lengthAdjust='spacingAndGlyphs'>1500</text>
+<text x='630.06' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='21.36px' lengthAdjust='spacingAndGlyphs'>2000</text>
+<text x='343.07' y='567.53' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='28.02px' lengthAdjust='spacingAndGlyphs'>Rank</text>
+<text x='676.69' y='267.44' style='font-size: 12.00px; font-family: sans;' textLength='31.36px' lengthAdjust='spacingAndGlyphs'>Chain</text>
+<line x1='678.42' y1='283.30' x2='692.24' y2='283.30' style='stroke-width: 1.07; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='678.42' y1='300.58' x2='692.24' y2='300.58' style='stroke-width: 1.07; stroke: #D1E1EC; stroke-linecap: butt;' />
+<text x='699.95' y='287.78' style='font-size: 13.00px; font-family: sans;' textLength='7.23px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='699.95' y='305.06' style='font-size: 13.00px; font-family: sans;' textLength='7.23px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='27.38' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='211.32px' lengthAdjust='spacingAndGlyphs'>mcmc_rank_overlay (not all bins)</text>
+</g>
+</svg>

--- a/tests/testthat/data-for-mcmc-tests.R
+++ b/tests/testthat/data-for-mcmc-tests.R
@@ -73,4 +73,11 @@ vdiff_dframe_chains_lp <- vdiff_dframe_chains_divergences
 vdiff_dframe_chains_lp$Parameter <- NULL
 vdiff_dframe_chains_lp$Value <- runif(2000, -100, -50)
 
+vdiff_dframe_rank_overlay_bins_test <- posterior::as_draws_df(
+  list(
+    list(theta = -2 + 0.003 * 1:1000 + stats::arima.sim(list(ar = 0.7), n = 1000, sd = 0.5)),
+    list(theta = 1 + -0.01 * 1:1000 + stats::arima.sim(list(ar = 0.7), n = 1000, sd = 0.5))
+  )
+)
+
 set.seed(seed = NULL)

--- a/tests/testthat/test-mcmc-traces.R
+++ b/tests/testthat/test-mcmc-traces.R
@@ -154,6 +154,9 @@ test_that("mcmc_rank_overlay renders correctly", {
     n_bins = 4
   )
 
+  # https://github.com/stan-dev/bayesplot/issues/331
+  p_not_all_bins_exist <- mcmc_rank_overlay(vdiff_dframe_rank_overlay_bins_test)
+
   vdiffr::expect_doppelganger("mcmc_rank_overlay (default)", p_base)
   vdiffr::expect_doppelganger(
     "mcmc_rank_overlay (reference line)",
@@ -164,6 +167,9 @@ test_that("mcmc_rank_overlay renders correctly", {
     "mcmc_rank_overlay (wide bins)",
     p_one_param_wide_bins
   )
+
+  # https://github.com/stan-dev/bayesplot/issues/331
+  vdiffr::expect_doppelganger("mcmc_rank_overlay (not all bins)", p_not_all_bins_exist)
 })
 
 test_that("mcmc_rank_hist renders correctly", {


### PR DESCRIPTION
fixes #331

Code to test: 

```r
x <- posterior::as_draws_array(
  list(
    list(theta = -2 + 0.003 * 1:1000 + arima.sim(list(ar = 0.7), n = 1000, sd = 0.5)),
    list(theta = 1 + -0.01 * 1:1000 + arima.sim(list(ar = 0.7), n = 1000, sd = 0.5))
  )
)
bayesplot::mcmc_rank_overlay(x)
```