### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -394,7 +394,7 @@ mcmc_violin <- function(
       set_hist_aes(freq),
       fill = get_color("mid"),
       color = get_color("mid_highlight"),
-      size = .25,
+      linewidth = .25,
       na.rm = TRUE,
       binwidth = binwidth,
       bins = bins,

--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -134,7 +134,7 @@ ppc_error_hist <-
       geom_histogram(
         fill = get_color("l"),
         color = get_color("lh"),
-        size = 0.25,
+        linewidth = 0.25,
         binwidth = binwidth,
         bins = bins,
         breaks = breaks

--- a/R/ppd-distributions.R
+++ b/R/ppd-distributions.R
@@ -168,7 +168,7 @@ ppd_hist <-
       fill = "ypred"
     )) +
       geom_histogram(
-        size = 0.25,
+        linewidth = 0.25,
         binwidth = binwidth,
         bins = bins,
         breaks = breaks

--- a/tests/testthat/test-mcmc-traces.R
+++ b/tests/testthat/test-mcmc-traces.R
@@ -51,7 +51,11 @@ test_that("mcmc_trace options work", {
   expect_equal(g1$coordinates$limits$x, c(5, 10))
 
   expect_gg(g2 <- mcmc_trace(arr, regex_pars = "beta", n_warmup = 10))
-  ll <- g2$labels
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    ll <- ggplot2::get_labs(g2)
+  } else {
+    ll <- g2$labels
+  }
   expect_true(all(c("xmin", "xmax", "ymin", "ymax") %in% names(ll)))
 
   expect_error(mcmc_trace(arr, iter1 = -1))


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the bayesplot package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
In addition, some deprecated functionality is avoided.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`).
There are some visual changes as well, but I'll leave that up to you to decide wether intervention is needed.

Best,
Teun