### PR TITLE
remove deprecated functions from available_ppc()

### DIFF
--- a/R/available-module-functions.R
+++ b/R/available-module-functions.R
@@ -130,6 +130,9 @@ print.bayesplot_function_list <- function(x, ...) {
       )
     }
 
+    # remove deprecated functions
+    return_funs <- setdiff(return_funs, "ppc_loo_pit")
+
     structure(
       return_funs,
       class = c("bayesplot_function_list", "character"),

--- a/bayesplot.Rproj
+++ b/bayesplot.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 29d8864e-c5c0-432d-b2d6-5838fba2f8d2
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-available_ppc.R
+++ b/tests/testthat/test-available_ppc.R
@@ -28,6 +28,7 @@ test_that("available_ppc works", {
 
   all_ppc_plots <- sort(grep("^ppc_", getNamespaceExports("bayesplot"), value = TRUE))
   all_ppc_plots <- grep("_data", all_ppc_plots, invert = TRUE, value = TRUE)
+  all_ppc_plots <- setdiff(all_ppc_plots, "ppc_loo_pit") # remove deprecated
   expect_identical(as.character(a), all_ppc_plots)
 
   b <- available_ppc("grouped")


### PR DESCRIPTION
closes #339

Removes `ppc_loo_pit()` from `available_ppc()` since it's deprecated. I think that's the only one we need to remove for now. 