### PR TITLE
Fix missing counts in ppc_bars_data()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     rlang (>= 0.3.0),
     stats,
     tibble (>= 2.0.0),
+    tidyr,
     tidyselect,
     utils
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Skip tests depending on Suggested dependency gridExtra if not installed by @MichaelChirico (#326) 
 * Skip tests depending on Suggested dependency rstantools if not installed by @MichaelChirico (#325)
 * Update GitHub actions workflows (#338)
+* Fix missing counts in `ppc_bars_data()` by @TeemuSailynoja, thanks @famuvie (#342)
 
 
 # bayesplot 1.11.1

--- a/R/ppc-discrete.R
+++ b/R/ppc-discrete.R
@@ -395,6 +395,7 @@ ppc_bars_data <-
   data <-
     reshape2::melt(tmp_data, id.vars = "group") %>%
     count(.data$group, .data$value, .data$variable) %>%
+    tidyr::complete(.data$group, .data$value, .data$variable, fill = list(n = 0)) %>% 
     group_by(.data$variable, .data$group) %>%
     mutate(proportion = .data$n / sum(.data$n)) %>%
     ungroup() %>%

--- a/tests/testthat/_snaps/ppc-discrete/ppc-bars-default.svg
+++ b/tests/testthat/_snaps/ppc-discrete/ppc-bars-default.svg
@@ -29,17 +29,20 @@
 <rect x='157.57' y='170.60' width='84.65' height='385.44' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='251.62' y='395.44' width='84.65' height='160.60' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='345.67' y='523.92' width='84.65' height='32.12' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='439.72' y='556.04' width='84.65' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='533.77' y='523.92' width='84.65' height='32.12' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='105.84' y1='319.96' x2='105.84' y2='50.15' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='199.89' y1='266.96' x2='199.89' y2='53.36' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='293.94' y1='477.35' x2='293.94' y2='331.20' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='388.00' y1='523.92' x2='388.00' y2='440.41' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='482.05' y1='522.32' x2='482.05' y2='493.41' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='388.00' y1='541.59' x2='388.00' y2='442.02' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='482.05' y1='556.04' x2='482.05' y2='506.26' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='576.10' y1='556.04' x2='576.10' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='105.84' cy='202.72' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='199.89' cy='202.72' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='293.94' cy='379.38' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='388.00' cy='491.80' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='482.05' cy='507.86' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='482.05' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='576.10' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='35.77,556.04 35.77,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/ppc-discrete/ppc-bars-grouped-default.svg
+++ b/tests/testthat/_snaps/ppc-discrete/ppc-bars-grouped-default.svg
@@ -29,17 +29,20 @@
 <rect x='101.73' y='278.75' width='40.27' height='277.29' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='146.47' y='371.18' width='40.27' height='184.86' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='191.21' y='509.83' width='40.27' height='46.22' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='235.96' y='556.04' width='40.27' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='280.70' y='509.83' width='40.27' height='46.22' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='77.12' y1='442.82' x2='77.12' y2='68.47' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='121.86' y1='442.82' x2='121.86' y2='135.48' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='166.61' y1='509.83' x2='166.61' y2='366.56' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='211.35' y1='509.83' x2='211.35' y2='468.23' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='256.09' y1='509.83' x2='256.09' y2='509.83' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='211.35' y1='556.04' x2='211.35' y2='484.41' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='256.09' y1='556.04' x2='256.09' y2='530.62' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='300.84' y1='556.04' x2='300.84' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='77.12' cy='232.54' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='121.86' cy='324.97' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='166.61' cy='463.61' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='211.35' cy='509.83' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='256.09' cy='509.83' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='211.35' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='256.09' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='300.84' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <line x1='43.78' y1='556.04' x2='334.17' y2='556.04' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='43.78' y1='556.04' x2='43.78' y2='44.09' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>
@@ -54,16 +57,21 @@
 <rect x='368.97' y='186.32' width='40.27' height='369.72' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='413.72' y='278.75' width='40.27' height='277.29' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='458.46' y='509.83' width='40.27' height='46.22' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='503.21' y='556.04' width='40.27' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='547.95' y='556.04' width='40.27' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='592.70' y='556.04' width='40.27' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='389.11' y1='468.23' x2='389.11' y2='232.54' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='433.85' y1='371.18' x2='433.85' y2='160.90' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='478.60' y1='489.03' x2='478.60' y2='324.97' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='523.34' y1='509.83' x2='523.34' y2='408.15' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='568.09' y1='509.83' x2='568.09' y2='509.83' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='523.34' y1='535.25' x2='523.34' y2='412.78' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='568.09' y1='556.04' x2='568.09' y2='509.83' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='612.83' y1='556.04' x2='612.83' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='389.11' cy='348.07' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='433.85' cy='301.86' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='478.60' cy='440.50' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='523.34' cy='509.83' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='568.09' cy='509.83' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='568.09' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='612.83' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <line x1='355.77' y1='556.04' x2='646.17' y2='556.04' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='355.77' y1='556.04' x2='355.77' y2='44.09' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>

--- a/tests/testthat/_snaps/ppc-discrete/ppc-bars-grouped-facet-args-prob-size.svg
+++ b/tests/testthat/_snaps/ppc-discrete/ppc-bars-grouped-facet-args-prob-size.svg
@@ -29,17 +29,20 @@
 <rect x='153.30' y='121.29' width='85.39' height='158.36' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='248.17' y='174.08' width='85.39' height='105.57' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='343.04' y='253.26' width='85.39' height='26.39' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='437.92' y='279.65' width='85.39' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='532.79' y='253.26' width='85.39' height='26.39' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='101.12' y1='121.29' x2='101.12' y2='55.31' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='195.99' y1='167.48' x2='195.99' y2='108.10' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='290.86' y1='246.66' x2='290.86' y2='200.47' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='385.74' y1='253.26' x2='385.74' y2='240.06' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='480.61' y1='253.26' x2='480.61' y2='253.26' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='385.74' y1='279.65' x2='385.74' y2='259.85' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='480.61' y1='279.65' x2='480.61' y2='279.65' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='575.48' y1='279.65' x2='575.48' y2='279.65' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='101.12' cy='94.90' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='195.99' cy='147.69' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='290.86' cy='226.86' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='385.74' cy='253.26' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='480.61' cy='253.26' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='385.74' cy='279.65' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='480.61' cy='279.65' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='575.48' cy='279.65' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <line x1='30.44' y1='279.65' x2='646.17' y2='279.65' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='30.44' y1='279.65' x2='30.44' y2='44.09' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>
@@ -54,16 +57,21 @@
 <rect x='58.42' y='344.90' width='85.39' height='211.14' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='153.30' y='397.69' width='85.39' height='158.36' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='248.17' y='529.65' width='85.39' height='26.39' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='343.04' y='556.04' width='85.39' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='437.92' y='556.04' width='85.39' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='532.79' y='556.04' width='85.39' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='101.12' y1='470.27' x2='101.12' y2='404.28' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='195.99' y1='424.08' x2='195.99' y2='371.29' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='290.86' y1='503.26' x2='290.86' y2='476.86' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='385.74' y1='529.65' x2='385.74' y2='503.26' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='480.61' y1='529.65' x2='480.61' y2='529.65' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='480.61' y1='556.04' x2='480.61' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='575.48' y1='556.04' x2='575.48' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='101.12' cy='437.28' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='195.99' cy='410.88' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='290.86' cy='490.06' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='385.74' cy='529.65' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='480.61' cy='529.65' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='480.61' cy='556.04' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='575.48' cy='556.04' r='2.04' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <line x1='30.44' y1='556.04' x2='646.17' y2='556.04' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='30.44' y1='556.04' x2='30.44' y2='320.49' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>

--- a/tests/testthat/_snaps/ppc-discrete/ppc-bars-prob-0-33-width-size-fatten.svg
+++ b/tests/testthat/_snaps/ppc-discrete/ppc-bars-prob-0-33-width-size-fatten.svg
@@ -29,17 +29,20 @@
 <rect x='170.73' y='50.15' width='49.78' height='505.89' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='270.30' y='345.25' width='49.78' height='210.79' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='369.87' y='513.89' width='49.78' height='42.16' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='469.43' y='556.04' width='49.78' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='569.00' y='513.89' width='49.78' height='42.16' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='96.05' y1='133.83' x2='96.05' y2='50.78' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='195.62' y1='175.99' x2='195.62' y2='50.15' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='295.19' y1='386.78' x2='295.19' y2='303.10' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='394.76' y1='485.22' x2='394.76' y2='458.24' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='494.32' y1='499.76' x2='494.32' y2='485.85' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='394.76' y1='513.25' x2='394.76' y2='471.73' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='494.32' y1='556.04' x2='494.32' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='593.89' y1='556.04' x2='593.89' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='96.05' cy='92.31' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='195.62' cy='92.31' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='295.19' cy='324.18' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='394.76' cy='471.73' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='494.32' cy='492.81' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='494.32' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='593.89' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='43.78,556.04 43.78,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/ppc-discrete/ppc-bars-width-size-fatten.svg
+++ b/tests/testthat/_snaps/ppc-discrete/ppc-bars-width-size-fatten.svg
@@ -29,17 +29,20 @@
 <rect x='164.41' y='170.60' width='50.45' height='385.44' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='265.30' y='395.44' width='50.45' height='160.60' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='366.19' y='523.92' width='50.45' height='32.12' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
+<rect x='467.08' y='556.04' width='50.45' height='0.00' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <rect x='567.97' y='523.92' width='50.45' height='32.12' style='stroke-width: 1.07; stroke: #B3CDE0; stroke-linecap: butt; stroke-linejoin: miter; fill: #D1E1EC;' />
 <line x1='88.74' y1='319.96' x2='88.74' y2='50.15' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='189.63' y1='266.96' x2='189.63' y2='53.36' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <line x1='290.52' y1='477.35' x2='290.52' y2='331.20' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='391.42' y1='523.92' x2='391.42' y2='440.41' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
-<line x1='492.31' y1='522.32' x2='492.31' y2='493.41' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='391.42' y1='541.59' x2='391.42' y2='442.02' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='492.31' y1='556.04' x2='492.31' y2='506.26' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
+<line x1='593.20' y1='556.04' x2='593.20' y2='556.04' style='stroke-width: 2.13; stroke: #03396C; stroke-linecap: butt;' />
 <circle cx='88.74' cy='202.72' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='189.63' cy='202.72' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='290.52' cy='379.38' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 <circle cx='391.42' cy='491.80' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
-<circle cx='492.31' cy='507.86' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='492.31' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
+<circle cx='593.20' cy='556.04' r='3.38' style='stroke-width: 1.42; stroke: #03396C; fill: #03396C;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='35.77,556.04 35.77,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />

--- a/tests/testthat/test-ppc-discrete.R
+++ b/tests/testthat/test-ppc-discrete.R
@@ -68,15 +68,15 @@ test_that("ppc_bars_data includes all levels", {
   # yrep has more unique values than y
   d2 <- ppc_bars_data(y_ord2, yrep_ord)
   expect_equal(d2$x, 1:4)
-  expect_equal(d2$y_obs, c(NA, sum(tab[1:2]), tab[3:4]))
+  expect_equal(d2$y_obs, c(0, sum(tab[1:2]), tab[3:4]))
 
   # y has more unique values than yrep
   d3 <- ppc_bars_data(y_ord, yrep_ord2)
   expect_equal(d3$x, 1:4)
   expect_equal(d3$y_obs, tab)
-  expect_equivalent(d3$l[2], NA_real_)
-  expect_equivalent(d3$m[2], NA_real_)
-  expect_equivalent(d3$h[2], NA_real_)
+  expect_equivalent(d3$l[2], 0)
+  expect_equivalent(d3$m[2], 0)
+  expect_equivalent(d3$h[2], 0)
 })
 
 


### PR DESCRIPTION
Fixes #266.

# Summary
As explained excellently by @famuvie in #266, `ppc_bars_data()` has been miscounting the summary statistics for `yrep`.
**_This fix would add tidyr as a dependency_**, but as we already have multiply tidyverse packages, I hope this isn't an issue.