### PR TITLE
combining ppc_error_scatter_avg_vs_x with ppc_error_scatter_avg(x = x)

### DIFF
--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -54,10 +54,12 @@
 #'    `y` and each dataset (row) in `yrep`. For each individual data point
 #'    `y[n]` the average error is the average of the errors for `y[n]` computed
 #'    over the the draws from the posterior predictive distribution.
+#'
+#'    When the optional `x` argument is provided, the average error is plotted
+#'    on the y-axis and the predictor variable `x` is plotted on the x-axis.
 #'   }
 #'   \item{`ppc_error_scatter_avg_vs_x()`}{
-#'    Same as `ppc_error_scatter_avg()`, except the average is plotted on the
-#'    y-axis and a predictor variable `x` is plotted on the x-axis.
+#'    Deprecated. Use `ppc_error_scatter_avg(x = x)` instead.
 #'   }
 #'   \item{`ppc_error_binned()`}{
 #'    Intended for use with binomial data. A separate binned error plot (similar
@@ -92,7 +94,7 @@
 #' ppc_error_scatter_avg(y, yrep)
 #'
 #' x <- example_x_data()
-#' ppc_error_scatter_avg_vs_x(y, yrep, x)
+#' ppc_error_scatter_avg(y, yrep, x)
 #'
 #' \dontrun{
 #' # binned error plot with binomial model from rstanarm
@@ -217,6 +219,7 @@ ppc_error_scatter <-
 ppc_error_scatter_avg <-
   function(y,
            yrep,
+           x = NULL,
            ...,
            stat = "mean",
            size = 2.5,
@@ -225,19 +228,31 @@ ppc_error_scatter_avg <-
 
     y <- validate_y(y)
     yrep <- validate_predictions(yrep, length(y))
+
+    if (!missing(x)) {
+      qx <- enquo(x)
+      x <- validate_x(x, y)
+    }
     errors <- compute_errors(y, yrep)
 
     stat <- as_tagged_function({{ stat }})
 
     ppc_scatter_avg(
-      y = y,
+      y = if (is_null(x)) y else x,
       yrep = errors,
       size = size,
       alpha = alpha,
       ref_line = FALSE,
       stat = stat
     ) +
-      labs(x = error_avg_label(stat), y = y_label())
+      labs(
+        x = error_avg_label(stat),
+        y = if (is_null(x)) y_label() else as_label((qx))
+        ) + if (is_null(x)) {
+          NULL
+        } else {
+          coord_flip()
+        }
   }
 
 
@@ -285,6 +300,9 @@ ppc_error_scatter_avg_vs_x <- function(
     alpha = 0.8
 ) {
   check_ignored_arguments(...)
+
+  .Deprecated(new = "ppc_error_scatter_avg()",
+              msg = "Use ppc_error_scatter_avg(x = x) instead of ppc_error_scatter_avg_vs_x().")
 
   y <- validate_y(y)
   yrep <- validate_predictions(yrep, length(y))

--- a/tests/testthat/_snaps/ppc-errors/ppc-error-scatter-avg-with-x.svg
+++ b/tests/testthat/_snaps/ppc-errors/ppc-error-scatter-avg-with-x.svg
@@ -1,0 +1,166 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNDAuNDN8NzE0LjAyfDI0Ljg1fDU0Mi4zMA=='>
+    <rect x='40.43' y='24.85' width='673.60' height='517.45' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDAuNDN8NzE0LjAyfDI0Ljg1fDU0Mi4zMA==)'>
+<circle cx='71.04' cy='158.92' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='77.23' cy='368.37' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='83.41' cy='199.75' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='89.60' cy='323.67' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='95.79' cy='219.77' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='101.97' cy='378.64' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='108.16' cy='403.26' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='114.34' cy='364.69' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='120.53' cy='449.63' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='126.71' cy='357.42' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='132.90' cy='166.96' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='139.08' cy='427.70' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='145.27' cy='394.84' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='151.45' cy='393.55' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='157.64' cy='410.15' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='163.83' cy='210.44' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='170.01' cy='363.23' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='176.20' cy='333.32' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='182.38' cy='393.37' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='188.57' cy='131.12' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='194.75' cy='157.14' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='200.94' cy='213.39' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='207.12' cy='116.95' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='213.31' cy='128.09' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='219.49' cy='500.12' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='225.68' cy='351.48' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='231.87' cy='483.26' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='238.05' cy='48.38' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='244.24' cy='221.37' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='250.42' cy='443.44' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='256.61' cy='263.84' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='262.79' cy='240.62' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='268.98' cy='281.71' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='275.16' cy='214.70' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='281.35' cy='394.70' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='287.53' cy='342.83' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='293.72' cy='333.14' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='299.91' cy='345.42' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='306.09' cy='204.57' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='312.28' cy='277.03' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='318.46' cy='458.83' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='324.65' cy='268.60' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='330.83' cy='374.66' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='337.02' cy='265.37' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='343.20' cy='243.15' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='349.39' cy='409.01' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='355.57' cy='275.71' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='361.76' cy='279.40' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='367.95' cy='169.16' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='374.13' cy='198.21' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='380.32' cy='371.64' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='386.50' cy='408.59' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='392.69' cy='248.62' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='398.87' cy='236.31' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='405.06' cy='502.35' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='411.24' cy='262.11' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='417.43' cy='207.68' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='423.62' cy='442.88' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='429.80' cy='198.88' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='435.99' cy='131.23' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='442.17' cy='381.72' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='448.36' cy='347.96' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='454.54' cy='518.78' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='460.73' cy='323.28' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='466.91' cy='152.73' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='473.10' cy='137.81' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='479.28' cy='477.14' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='485.47' cy='259.10' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='491.66' cy='312.12' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='497.84' cy='422.43' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='504.03' cy='300.82' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='510.21' cy='322.73' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='516.40' cy='319.31' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='522.58' cy='85.62' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='528.77' cy='400.69' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='534.95' cy='74.98' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='541.14' cy='353.74' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='547.32' cy='418.32' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='553.51' cy='269.38' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='559.70' cy='252.47' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='565.88' cy='288.61' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='572.07' cy='185.49' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='578.25' cy='444.61' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='584.44' cy='393.65' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='590.62' cy='324.46' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='596.81' cy='302.81' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='602.99' cy='250.76' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='609.18' cy='128.97' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='615.36' cy='360.17' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='621.55' cy='359.46' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='627.74' cy='409.43' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='633.92' cy='255.42' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='640.11' cy='385.71' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='646.29' cy='342.58' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='652.48' cy='377.33' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='658.66' cy='196.47' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='664.85' cy='286.21' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='671.03' cy='276.52' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='677.22' cy='381.51' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+<circle cx='683.40' cy='366.21' r='3.02' style='stroke-width: 0.71; stroke: #005B96; stroke-opacity: 0.80; fill: #6497B1; fill-opacity: 0.80;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='40.43,542.30 40.43,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<text x='35.05' y='471.02' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='8.54px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='35.05' y='384.16' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='8.54px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='35.05' y='297.30' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='35.05' y='210.45' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='35.05' y='123.59' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='35.05' y='36.73' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='37.44,467.72 40.43,467.72 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.44,380.86 40.43,380.86 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.44,294.00 40.43,294.00 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.44,207.14 40.43,207.14 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.44,120.28 40.43,120.28 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='37.44,33.42 40.43,33.42 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='40.43,542.30 714.02,542.30 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<polyline points='64.86,545.29 64.86,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='219.49,545.29 219.49,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='374.13,545.29 374.13,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='528.77,545.29 528.77,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='683.40,545.29 683.40,542.30 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<text x='64.86' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='219.49' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='374.13' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='528.77' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='10.68px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='683.40' y='554.29' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='16.02px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='377.22' y='567.53' text-anchor='middle' style='font-size: 12.00px; font-family: sans;' textLength='98.07px' lengthAdjust='spacingAndGlyphs'>seq_along(vdiff_y)</text>
+<text transform='translate(17.07,323.49) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='30.02px' lengthAdjust='spacingAndGlyphs'>mean</text>
+<text transform='translate(17.07,293.47) rotate(-90)' style='font-size: 15.00px; font-family: sans;' textLength='5.00px' lengthAdjust='spacingAndGlyphs'>(</text>
+<text transform='translate(17.07,288.47) rotate(-90)' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text transform='translate(17.07,279.30) rotate(-90)' style='font-size: 12.00px; font-family: sans;' textLength='9.32px' lengthAdjust='spacingAndGlyphs'>−</text>
+<text transform='translate(17.07,267.75) rotate(-90)' style='font-size: 12.00px; font-style: italic; font-family: sans;' textLength='6.00px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text transform='translate(19.29,260.79) rotate(-90)' style='font-size: 8.40px; font-family: sans;' textLength='2.80px' lengthAdjust='spacingAndGlyphs'>r</text>
+<text transform='translate(19.29,258.00) rotate(-90)' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>e</text>
+<text transform='translate(19.29,253.32) rotate(-90)' style='font-size: 8.40px; font-family: sans;' textLength='4.67px' lengthAdjust='spacingAndGlyphs'>p</text>
+<text transform='translate(17.07,248.65) rotate(-90)' style='font-size: 15.00px; font-family: sans;' textLength='4.99px' lengthAdjust='spacingAndGlyphs'>)</text>
+<text x='40.43' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='194.51px' lengthAdjust='spacingAndGlyphs'>ppc_error_scatter_avg (with x)</text>
+</g>
+</svg>

--- a/tests/testthat/test-ppc-errors.R
+++ b/tests/testthat/test-ppc-errors.R
@@ -26,6 +26,10 @@ test_that("ppc_error_scatter_avg returns ggplot2 object", {
   skip_if_not_installed("rstantools")
   expect_gg(ppc_error_scatter_avg(y, yrep))
   expect_gg(ppc_error_scatter_avg(y, yrep[1:5, ]))
+
+  # when x is provided
+  expect_gg(ppc_error_scatter_avg(y, yrep, x = rnorm(length(y))))
+  expect_gg(ppc_error_scatter_avg(y, yrep[1:5, ], x = rnorm(length(y))))
 })
 
 test_that("ppc_error_scatter_avg same as ppc_error_scatter if nrow(yrep) = 1", {
@@ -42,8 +46,12 @@ test_that("ppc_error_scatter_avg same as ppc_error_scatter if nrow(yrep) = 1", {
 
 test_that("ppc_error_scatter_avg_vs_x returns ggplot2 object", {
   skip_if_not_installed("rstantools")
-  expect_gg(ppc_error_scatter_avg_vs_x(y, yrep, x = rnorm(length(y))))
-  expect_gg(ppc_error_scatter_avg_vs_x(y, yrep[1:5, ], x = rnorm(length(y))))
+
+  # expect warning
+  expect_warning(expect_gg(ppc_error_scatter_avg_vs_x(y, yrep, x = rnorm(length(y)))),
+                 "Use ppc_error_scatter_avg\\(x = x\\) instead of ppc_error_scatter_avg_vs_x\\(\\).")
+  expect_warning(expect_gg(ppc_error_scatter_avg_vs_x(y, yrep[1:5, ], x = rnorm(length(y)))),
+                 "Use ppc_error_scatter_avg\\(x = x\\) instead of ppc_error_scatter_avg_vs_x\\(\\).")
 })
 
 test_that("ppc_error_binned returns ggplot object", {
@@ -105,6 +113,9 @@ test_that("ppc_error_scatter_avg renders correctly", {
 
   p_base <- ppc_error_scatter_avg(vdiff_y, vdiff_yrep)
   vdiffr::expect_doppelganger("ppc_error_scatter_avg (default)", p_base)
+
+  p_base_x <- ppc_error_scatter_avg(vdiff_y, vdiff_yrep, x = seq_along(vdiff_y))
+  vdiffr::expect_doppelganger("ppc_error_scatter_avg (with x)", p_base_x)
 })
 
 test_that("ppc_error_scatter_avg_grouped renders correctly", {
@@ -121,8 +132,13 @@ test_that("ppc_error_scatter_avg_vs_x renders correctly", {
   testthat::skip_if_not_installed("vdiffr")
   skip_on_r_oldrel()
 
-  p_base <- ppc_error_scatter_avg_vs_x(vdiff_y, vdiff_yrep, x = seq_along(vdiff_y))
+  # expect warning
+  expect_warning(
+    p_base <- ppc_error_scatter_avg_vs_x(vdiff_y, vdiff_yrep, x = seq_along(vdiff_y)),
+    "Use ppc_error_scatter_avg\\(x = x\\) instead of ppc_error_scatter_avg_vs_x\\(\\)."
+  )
   vdiffr::expect_doppelganger("ppc_error_scatter_avg_vs_x (default)", p_base)
+
 })
 
 test_that("ppc_error_binned renders correctly", {


### PR DESCRIPTION
In #361, we discussed the possibility of rearranging plots for easier usage. As I mentioned in the sub-issue #364, one of the ideas I had was combining `ppc_error_scatter_avg_vs_x()` with `ppc_error_scatter_avg(x = x)`. The simple idea behind this is that these two functions are fairly similar, and all `ppc_error_scatter_avg_vs_x()` does is format the `x` variable appropriately and then call `ppc_error_scatter_avg()`. Therefore, I think combining these two functions would result in a smoother user experience by reducing the number of similar functions.

This PR addresses my work on that idea.

- [x] add `x` argument
- [x] update the tests
- [ ] update the documentation 
- [x] deprecate `ppc_error_scatter_avg_vs_x()`

### Results
To show the results of the work, I re-created the examples used at [PPC-errors documentation](https://mc-stan.org/bayesplot/reference/PPC-errors.html).
```r
y <- example_y_data()
yrep <- example_yrep_draws()
x <- example_x_data()

ppc_error_scatter_avg(y, yrep)
``` 

<img width="1252" height="818" alt="scatter_avg" src="https://github.com/user-attachments/assets/f65c278d-d56d-4b25-9b27-8cef31cd5178" />

```r
ppc_error_scatter_avg_vs_x(y, yrep, x)

Warning message:
In ppc_error_scatter_avg_vs_x(y, yrep, x) :
  Use ppc_error_scatter_avg(x = x) instead of ppc_error_scatter_avg_vs_x().
``` 
<img width="1252" height="818" alt="scatter_avg_vs_x" src="https://github.com/user-attachments/assets/e3b6b7ae-3ac4-440e-9fae-3ecc11252ec2" />

```r
ppc_error_scatter_avg(y, yrep, x)
``` 
<img width="1252" height="818" alt="scatter_avg_x" src="https://github.com/user-attachments/assets/4547fe4b-207f-4600-a1d5-1b128a73215b" />

It seems like functions are working as intended, producing correct plots, and `ppc_error_scatter_avg_vs_x()` is producing the correct deprecation warning.