### PR TITLE
inserting an empty line to fix documentation

### DIFF
--- a/R/ppc-discrete.R
+++ b/R/ppc-discrete.R
@@ -89,6 +89,7 @@
 #'    with `discrete = TRUE`.
 #' - [ppc_pit_ecdf()] and [ppc_pit_ecdf_grouped()] can also handle discrete
 #'   variables to plot PIT-ECDF of the empirical PIT values.
+#'
 #' These functions are not limited to discrete outcomes, but offer discrete-friendly
 #' displays for integer-valued statistics.
 #'

--- a/man/PPC-discrete.Rd
+++ b/man/PPC-discrete.Rd
@@ -172,9 +172,10 @@ from predictive draws when \code{discrete = TRUE}.
 with \code{discrete = TRUE}.
 \item \code{\link[=ppc_pit_ecdf]{ppc_pit_ecdf()}} and \code{\link[=ppc_pit_ecdf_grouped]{ppc_pit_ecdf_grouped()}} can also handle discrete
 variables to plot PIT-ECDF of the empirical PIT values.
+}
+
 These functions are not limited to discrete outcomes, but offer discrete-friendly
 displays for integer-valued statistics.
-}
 }
 
 \examples{
@@ -251,7 +252,7 @@ Visualizing count data regressions using rootograms.
 \url{https://arxiv.org/abs/1605.01311}.
 }
 \seealso{
-Other PPCs: 
+Other PPCs:
 \code{\link{PPC-censoring}},
 \code{\link{PPC-distributions}},
 \code{\link{PPC-errors}},


### PR DESCRIPTION
I just realised that in the updated ppc-discrete documentation that I updated at #369, I missed inserting an empty line, so a sentence that doesn’t belong to the list seems like it’s in the list. Here is a quick PR to fix that before the release of next version